### PR TITLE
feat: implement GET /api/v1/users endpoint

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,6 +63,12 @@ tools/
 
 ## コーディングルール
 
+### domain/model
+
+- GORM タグ付きの struct（エンティティ）はここに定義する
+- 複数のモデルをまとめた集約型（例: `XxxWithRelations`）もここに定義する
+- usecase や openapi など他のパッケージの型には依存しない
+
 ### handler
 
 - `openapi` パッケージの型（`openapi.XxxParams`, `openapi.XxxJSONRequestBody` など）を受け取り、usecase の `Input` 型に変換して渡す
@@ -77,7 +83,11 @@ func (h *XxxHandler) Xxx(ctx echo.Context, params openapi.XxxParams) error {
     if err != nil {
         return err
     }
-    return ctx.JSON(http.StatusOK, toResponse(output))
+    response, err := openapi.NewXxxResponse(output)
+    if err != nil {
+        return apperror.InternalServerError(err)
+    }
+    return ctx.JSON(http.StatusOK, response)
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,12 @@ tools/
 
 ## コーディングルール
 
+### domain/model
+
+- GORM タグ付きの struct（エンティティ）はここに定義する
+- 複数のモデルをまとめた集約型（例: `XxxWithRelations`）もここに定義する
+- usecase や openapi など他のパッケージの型には依存しない
+
 ### handler
 
 - `openapi` パッケージの型（`openapi.XxxParams`, `openapi.XxxJSONRequestBody` など）を受け取り、usecase の `Input` 型に変換して渡す
@@ -77,7 +83,11 @@ func (h *XxxHandler) Xxx(ctx echo.Context, params openapi.XxxParams) error {
     if err != nil {
         return err
     }
-    return ctx.JSON(http.StatusOK, toResponse(output))
+    response, err := openapi.NewXxxResponse(output)
+    if err != nil {
+        return apperror.InternalServerError(err)
+    }
+    return ctx.JSON(http.StatusOK, response)
 }
 ```
 

--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -17,7 +17,6 @@ func ProvideDB(cfg *config.Config) (*gorm.DB, error) {
 }
 
 // ProvideRepositories は全リポジトリのコンストラクタを Container に登録します。
-// dig が *gorm.DB を解決して各リポジトリに注入します。
 func ProvideRepositories(ct *Container) {
 	ct.MustProvide(persistence.NewUserRepository)
 	ct.MustProvide(persistence.NewDateSpotRepository)
@@ -37,4 +36,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewGetDateSpotsUsecase)
 	ct.MustProvide(usecase.NewSignupUsecase)
 	ct.MustProvide(usecase.NewLoginUsecase)
+	ct.MustProvide(usecase.NewGetUsersUsecase)
 }

--- a/internal/domain/model/course.go
+++ b/internal/domain/model/course.go
@@ -3,11 +3,12 @@ package model
 import "time"
 
 type Course struct {
-	ID         uint      `gorm:"primaryKey;autoIncrement"`
-	UserID     uint      `gorm:"not null;index"`
-	TravelMode string    `gorm:"not null"`
-	Authority  string    `gorm:"not null"`
-	CreatedAt  time.Time `gorm:"not null;autoCreateTime"`
-	UpdatedAt  time.Time `gorm:"not null;autoUpdateTime"`
-	User       *User     `gorm:"foreignKey:UserID"`
+	ID         uint        `gorm:"primaryKey;autoIncrement"`
+	UserID     uint        `gorm:"not null;index"`
+	TravelMode string      `gorm:"not null"`
+	Authority  string      `gorm:"not null"`
+	CreatedAt  time.Time   `gorm:"not null;autoCreateTime"`
+	UpdatedAt  time.Time   `gorm:"not null;autoUpdateTime"`
+	User       *User       `gorm:"foreignKey:UserID"`
+	DuringSpots []*DuringSpot `gorm:"foreignKey:CourseID"`
 }

--- a/internal/domain/model/user.go
+++ b/internal/domain/model/user.go
@@ -10,13 +10,22 @@ const (
 )
 
 type User struct {
-	ID             uint      `gorm:"primaryKey;autoIncrement"`
-	Name           string    `gorm:"not null;uniqueIndex"`
-	Email          string    `gorm:"not null;uniqueIndex"`
-	Gender         Gender    `gorm:"not null"`
+	ID             uint   `gorm:"primaryKey;autoIncrement"`
+	Name           string `gorm:"not null;uniqueIndex"`
+	Email          string `gorm:"not null;uniqueIndex"`
+	Gender         Gender `gorm:"not null"`
 	Image          *string
 	Admin          bool      `gorm:"not null;default:false"`
 	PasswordDigest string    `gorm:"not null"`
 	CreatedAt      time.Time `gorm:"not null;autoCreateTime"`
 	UpdatedAt      time.Time `gorm:"not null;autoUpdateTime"`
+}
+
+// UserWithRelations はユーザーと関連データをまとめた中間型です。
+type UserWithRelations struct {
+	User         *User
+	FollowerIDs  []int
+	FollowingIDs []int
+	Courses      []*Course
+	Reviews      []*DateSpotReview
 }

--- a/internal/domain/repository/course_repository.go
+++ b/internal/domain/repository/course_repository.go
@@ -3,9 +3,10 @@ package repository
 import (
 	"context"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 )
 
 type CourseRepository interface {
 	Create(ctx context.Context, course *model.Course) error
+	FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error)
 }

--- a/internal/domain/repository/date_spot_review_repository.go
+++ b/internal/domain/repository/date_spot_review_repository.go
@@ -3,9 +3,10 @@ package repository
 import (
 	"context"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 )
 
 type DateSpotReviewRepository interface {
 	Create(ctx context.Context, review *model.DateSpotReview) error
+	FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error)
 }

--- a/internal/domain/repository/relationship_repository.go
+++ b/internal/domain/repository/relationship_repository.go
@@ -3,9 +3,11 @@ package repository
 import (
 	"context"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 )
 
 type RelationshipRepository interface {
 	Create(ctx context.Context, relationship *model.Relationship) error
+	FindFollowingsByUserID(ctx context.Context, userID uint) ([]*model.User, error)
+	FindFollowersByUserID(ctx context.Context, userID uint) ([]*model.User, error)
 }

--- a/internal/domain/repository/user_repository.go
+++ b/internal/domain/repository/user_repository.go
@@ -8,7 +8,13 @@ import (
 
 type UserRepository interface {
 	Create(ctx context.Context, user *model.User) error
+	FindByID(ctx context.Context, id uint) (*model.User, error)
 	FindByName(ctx context.Context, name string) (*model.User, error)
+	Search(ctx context.Context, name *string) ([]*model.User, error)
 	ExistsByName(ctx context.Context, name string) (bool, error)
 	ExistsByEmail(ctx context.Context, email string) (bool, error)
+	FindFollowerIDsByUserID(ctx context.Context, userID uint) ([]int, error)
+	FindFollowingIDsByUserID(ctx context.Context, userID uint) ([]int, error)
+	Update(ctx context.Context, user *model.User) error
+	Delete(ctx context.Context, id uint) error
 }

--- a/internal/infrastructure/persistence/course_repository.go
+++ b/internal/infrastructure/persistence/course_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	"gorm.io/gorm"
 )
@@ -24,4 +24,18 @@ func (r *courseRepository) Create(ctx context.Context, course *model.Course) err
 	}
 	slog.InfoContext(ctx, "courseRepository.Create succeeded", "course_id", course.ID)
 	return nil
+}
+
+// FindByUserID は指定ユーザーのコース一覧を DuringSpots→DateSpot 込みで返します。
+func (r *courseRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error) {
+	var courses []*model.Course
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Preload("User").
+		Preload("DuringSpots.DateSpot").
+		Find(&courses).Error; err != nil {
+		slog.ErrorContext(ctx, "courseRepository.FindByUserID failed", "err", err)
+		return nil, err
+	}
+	return courses, nil
 }

--- a/internal/infrastructure/persistence/date_spot_review_repository.go
+++ b/internal/infrastructure/persistence/date_spot_review_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	"gorm.io/gorm"
 )
@@ -24,4 +24,17 @@ func (r *dateSpotReviewRepository) Create(ctx context.Context, review *model.Dat
 	}
 	slog.InfoContext(ctx, "dateSpotReviewRepository.Create succeeded", "review_id", review.ID)
 	return nil
+}
+
+// FindByUserID は指定ユーザーのレビュー一覧を DateSpot 込みで返します。
+func (r *dateSpotReviewRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error) {
+	var reviews []*model.DateSpotReview
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Preload("DateSpot").
+		Find(&reviews).Error; err != nil {
+		slog.ErrorContext(ctx, "dateSpotReviewRepository.FindByUserID failed", "err", err)
+		return nil, err
+	}
+	return reviews, nil
 }

--- a/internal/infrastructure/persistence/relationship_repository.go
+++ b/internal/infrastructure/persistence/relationship_repository.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	"gorm.io/gorm"
 )
@@ -24,4 +24,32 @@ func (r *relationshipRepository) Create(ctx context.Context, relationship *model
 	}
 	slog.InfoContext(ctx, "relationshipRepository.Create succeeded", "relationship_id", relationship.ID)
 	return nil
+}
+
+// FindFollowingsByUserID は指定ユーザーがフォローしているユーザー一覧（管理者除く）を返します。
+// Rails: user.followings.includes(...).non_admins に相当します。
+func (r *relationshipRepository) FindFollowingsByUserID(ctx context.Context, userID uint) ([]*model.User, error) {
+	var users []*model.User
+	if err := r.db.WithContext(ctx).
+		Joins("JOIN relationships ON relationships.follow_id = users.id").
+		Where("relationships.user_id = ? AND users.admin = false", userID).
+		Find(&users).Error; err != nil {
+		slog.ErrorContext(ctx, "relationshipRepository.FindFollowingsByUserID failed", "err", err)
+		return nil, err
+	}
+	return users, nil
+}
+
+// FindFollowersByUserID は指定ユーザーをフォローしているユーザー一覧（管理者除く）を返します。
+// Rails: user.followers.includes(...).non_admins に相当します。
+func (r *relationshipRepository) FindFollowersByUserID(ctx context.Context, userID uint) ([]*model.User, error) {
+	var users []*model.User
+	if err := r.db.WithContext(ctx).
+		Joins("JOIN relationships ON relationships.user_id = users.id").
+		Where("relationships.follow_id = ? AND users.admin = false", userID).
+		Find(&users).Error; err != nil {
+		slog.ErrorContext(ctx, "relationshipRepository.FindFollowersByUserID failed", "err", err)
+		return nil, err
+	}
+	return users, nil
 }

--- a/internal/infrastructure/persistence/user_repository.go
+++ b/internal/infrastructure/persistence/user_repository.go
@@ -27,8 +27,20 @@ func (r *userRepository) Create(ctx context.Context, user *model.User) error {
 	return nil
 }
 
+// FindByID は id でユーザーを検索します。
+func (r *userRepository) FindByID(ctx context.Context, id uint) (*model.User, error) {
+	var user model.User
+	if err := r.db.WithContext(ctx).First(&user, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, gorm.ErrRecordNotFound
+		}
+		slog.ErrorContext(ctx, "userRepository.FindByID failed", "err", err)
+		return nil, err
+	}
+	return &user, nil
+}
+
 // FindByName は name でユーザーを検索します。
-// 見つからない場合は gorm.ErrRecordNotFound を返します。
 func (r *userRepository) FindByName(ctx context.Context, name string) (*model.User, error) {
 	var user model.User
 	if err := r.db.WithContext(ctx).Where("name = ?", name).First(&user).Error; err != nil {
@@ -40,6 +52,20 @@ func (r *userRepository) FindByName(ctx context.Context, name string) (*model.Us
 	}
 	slog.InfoContext(ctx, "userRepository.FindByName succeeded", "user_id", user.ID)
 	return &user, nil
+}
+
+// Search は管理者を除くユーザーを名前で部分一致検索します。
+func (r *userRepository) Search(ctx context.Context, name *string) ([]*model.User, error) {
+	var users []*model.User
+	db := r.db.WithContext(ctx).Where("admin = false")
+	if name != nil && *name != "" {
+		db = db.Where("name LIKE ?", "%"+*name+"%")
+	}
+	if err := db.Find(&users).Error; err != nil {
+		slog.ErrorContext(ctx, "userRepository.Search failed", "err", err)
+		return nil, err
+	}
+	return users, nil
 }
 
 func (r *userRepository) ExistsByName(ctx context.Context, name string) (bool, error) {
@@ -61,4 +87,50 @@ func (r *userRepository) ExistsByEmail(ctx context.Context, email string) (bool,
 		return false, err
 	}
 	return count > 0, nil
+}
+
+// FindFollowerIDsByUserID は指定ユーザーをフォローしているユーザーのIDリストを返します。
+func (r *userRepository) FindFollowerIDsByUserID(ctx context.Context, userID uint) ([]int, error) {
+	var ids []int
+	if err := r.db.WithContext(ctx).
+		Table("relationships").
+		Where("follow_id = ?", userID).
+		Pluck("user_id", &ids).Error; err != nil {
+		slog.ErrorContext(ctx, "userRepository.FindFollowerIDsByUserID failed", "err", err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+// FindFollowingIDsByUserID は指定ユーザーがフォローしているユーザーのIDリストを返します。
+func (r *userRepository) FindFollowingIDsByUserID(ctx context.Context, userID uint) ([]int, error) {
+	var ids []int
+	if err := r.db.WithContext(ctx).
+		Table("relationships").
+		Where("user_id = ?", userID).
+		Pluck("follow_id", &ids).Error; err != nil {
+		slog.ErrorContext(ctx, "userRepository.FindFollowingIDsByUserID failed", "err", err)
+		return nil, err
+	}
+	return ids, nil
+}
+
+// Update はユーザー情報を更新します。
+func (r *userRepository) Update(ctx context.Context, user *model.User) error {
+	if err := r.db.WithContext(ctx).Save(user).Error; err != nil {
+		slog.ErrorContext(ctx, "userRepository.Update failed", "err", err)
+		return err
+	}
+	slog.InfoContext(ctx, "userRepository.Update succeeded", "user_id", user.ID)
+	return nil
+}
+
+// Delete はユーザーを削除します。
+func (r *userRepository) Delete(ctx context.Context, id uint) error {
+	if err := r.db.WithContext(ctx).Delete(&model.User{}, id).Error; err != nil {
+		slog.ErrorContext(ctx, "userRepository.Delete failed", "err", err)
+		return err
+	}
+	slog.InfoContext(ctx, "userRepository.Delete succeeded", "user_id", id)
+	return nil
 }

--- a/internal/interface/handler/get_api_v1_users.go
+++ b/internal/interface/handler/get_api_v1_users.go
@@ -3,14 +3,38 @@ package handler
 import (
 	"net/http"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type GetApiV1UsersHandler struct{}
+type GetApiV1UsersHandler struct {
+	InputPort usecase.GetUsersInputPort
+}
 
-func (h *GetApiV1UsersHandler) GetApiV1Users(ctx echo.Context, arg1 openapi.GetApiV1UsersParams) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *GetApiV1UsersHandler) GetApiV1Users(ctx echo.Context, params openapi.GetApiV1UsersParams) error {
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.GetUsersInput{
+		Name: params.Name,
+	})
+	if err != nil {
+		return err
+	}
+
+	responses := make([]openapi.UserResponseBody, 0, len(output.Users))
+	for _, uwr := range output.Users {
+		resp, err := openapi.BuildUserResponseBody(
+			uwr.User,
+			uwr.FollowerIDs,
+			uwr.FollowingIDs,
+			uwr.Courses,
+			uwr.Reviews,
+		)
+		if err != nil {
+			return apperror.InternalServerError(err)
+		}
+		responses = append(responses, resp)
+	}
+
+	return ctx.JSON(http.StatusOK, responses)
 }

--- a/internal/interface/handler/get_api_v1_users.go
+++ b/internal/interface/handler/get_api_v1_users.go
@@ -21,19 +21,9 @@ func (h *GetApiV1UsersHandler) GetApiV1Users(ctx echo.Context, params openapi.Ge
 		return err
 	}
 
-	responses := make([]openapi.UserResponseBody, 0, len(output.Users))
-	for _, uwr := range output.Users {
-		resp, err := openapi.BuildUserResponseBody(
-			uwr.User,
-			uwr.FollowerIDs,
-			uwr.FollowingIDs,
-			uwr.Courses,
-			uwr.Reviews,
-		)
-		if err != nil {
-			return apperror.InternalServerError(err)
-		}
-		responses = append(responses, resp)
+	responses, err := openapi.NewGetUsersResponse(output.Users)
+	if err != nil {
+		return apperror.InternalServerError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, responses)

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -18,11 +18,13 @@ func NewHandler(container *di.Container) *Handler {
 		GetApiV1DateSpotsHandler: GetApiV1DateSpotsHandler{
 			InputPort: di.MustInvoke[usecase.GetDateSpotsInputPort](container),
 		},
-		GetApiV1DateSpotsIdHandler:           GetApiV1DateSpotsIdHandler{},
-		GetApiV1GenresIdHandler:              GetApiV1GenresIdHandler{},
-		GetApiV1PrefecturesIdHandler:         GetApiV1PrefecturesIdHandler{},
-		GetApiV1TopHandler:                   GetApiV1TopHandler{},
-		GetApiV1UsersHandler:                 GetApiV1UsersHandler{},
+		GetApiV1DateSpotsIdHandler: GetApiV1DateSpotsIdHandler{},
+		GetApiV1GenresIdHandler:    GetApiV1GenresIdHandler{},
+		GetApiV1PrefecturesIdHandler: GetApiV1PrefecturesIdHandler{},
+		GetApiV1TopHandler:           GetApiV1TopHandler{},
+		GetApiV1UsersHandler: GetApiV1UsersHandler{
+			InputPort: di.MustInvoke[usecase.GetUsersInputPort](container),
+		},
 		GetApiV1UsersIdHandler:               GetApiV1UsersIdHandler{},
 		GetApiV1UsersUserIdFollowersHandler:  GetApiV1UsersUserIdFollowersHandler{},
 		GetApiV1UsersUserIdFollowingsHandler: GetApiV1UsersUserIdFollowingsHandler{},

--- a/internal/interface/openapi/users.go
+++ b/internal/interface/openapi/users.go
@@ -1,0 +1,164 @@
+package openapi
+
+import (
+	"github.com/daisuke-harada/date-courses-go/internal/domain/master"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+)
+
+// UserResponseBody は UserResponseData の代替型です。
+// CourseResponseDataBody / DateSpotReviewDataBody を使うことで
+// OpeningTime / ClosingTime の nullable を正しく扱います。
+type UserResponseBody struct {
+	Admin           bool                    `json:"admin"`
+	Courses         []CourseResponseDataBody `json:"courses"`
+	DateSpotReviews []DateSpotReviewDataBody `json:"date_spot_reviews"`
+	Email           string                  `json:"email"`
+	FollowerIds     []int                   `json:"followerIds"`
+	FollowingIds    []int                   `json:"followingIds"`
+	Gender          Gender                  `json:"gender"`
+	Id              int                     `json:"id"`
+	Image           ImageData               `json:"image"`
+	Name            string                  `json:"name"`
+}
+
+// CourseResponseDataBody は CourseResponseData の代替型です。
+// DateSpots フィールドに AddressAndDateSpotsDataResponse を使います。
+type CourseResponseDataBody struct {
+	Authority                  string                            `json:"authority"`
+	DateSpots                  []AddressAndDateSpotsDataResponse `json:"date_spots"`
+	Id                         int                               `json:"id"`
+	NoDuplicatePrefectureNames []string                          `json:"no_duplicate_prefecture_names"`
+	TravelMode                 string                            `json:"travel_mode"`
+	User                       UserData                          `json:"user"`
+}
+
+// DateSpotReviewDataBody は DateSpotReviewData の代替型です。
+// DateSpot フィールドに DateSpotDataResponse を使います。
+type DateSpotReviewDataBody struct {
+	Content  string               `json:"content"`
+	DateSpot DateSpotDataResponse `json:"date_spot"`
+	Id       int                  `json:"id"`
+	Rate     float32              `json:"rate"`
+}
+
+// BuildUserResponseBody は User と関連データから UserResponseBody を構築します。
+func BuildUserResponseBody(
+	user *model.User,
+	followerIDs, followingIDs []int,
+	courses []*model.Course,
+	reviews []*model.DateSpotReview,
+) (UserResponseBody, error) {
+	gender, err := NewGender(user.Gender)
+	if err != nil {
+		return UserResponseBody{}, err
+	}
+
+	courseResponses := make([]CourseResponseDataBody, 0, len(courses))
+	for _, c := range courses {
+		cr, err := buildCourseResponseBody(c)
+		if err != nil {
+			return UserResponseBody{}, err
+		}
+		courseResponses = append(courseResponses, cr)
+	}
+
+	reviewResponses := make([]DateSpotReviewDataBody, 0, len(reviews))
+	for _, rv := range reviews {
+		reviewResponses = append(reviewResponses, buildDateSpotReviewDataBody(rv))
+	}
+
+	if followerIDs == nil {
+		followerIDs = []int{}
+	}
+	if followingIDs == nil {
+		followingIDs = []int{}
+	}
+
+	return UserResponseBody{
+		Id:              int(user.ID),
+		Admin:           user.Admin,
+		Email:           user.Email,
+		Gender:          gender,
+		Image:           ImageData{Url: user.Image},
+		Name:            user.Name,
+		FollowerIds:     followerIDs,
+		FollowingIds:    followingIDs,
+		Courses:         courseResponses,
+		DateSpotReviews: reviewResponses,
+	}, nil
+}
+
+// buildCourseResponseBody は Course モデルから CourseResponseDataBody を構築します。
+// Course.User と Course.DuringSpots.DateSpot が Preload 済みであることを前提とします。
+func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, error) {
+	dateSpots := make([]AddressAndDateSpotsDataResponse, 0, len(course.DuringSpots))
+	prefectureIDSet := make(map[int]struct{})
+
+	for _, ds := range course.DuringSpots {
+		if ds.DateSpot == nil {
+			continue
+		}
+		dateSpots = append(dateSpots, newAddressAndDateSpotsData(ds.DateSpot))
+		if ds.DateSpot.PrefectureID != nil {
+			prefectureIDSet[*ds.DateSpot.PrefectureID] = struct{}{}
+		}
+	}
+
+	prefectureNames := make([]string, 0, len(prefectureIDSet))
+	for id := range prefectureIDSet {
+		name := master.PrefectureNameByID(id)
+		if name != "" {
+			prefectureNames = append(prefectureNames, name)
+		}
+	}
+
+	var courseUser UserData
+	if course.User != nil {
+		gender, err := NewGender(course.User.Gender)
+		if err != nil {
+			return CourseResponseDataBody{}, err
+		}
+		courseUser = UserData{
+			Id:     int(course.User.ID),
+			Name:   course.User.Name,
+			Email:  course.User.Email,
+			Gender: gender,
+			Image:  ImageData{Url: course.User.Image},
+			Admin:  course.User.Admin,
+		}
+	}
+
+	return CourseResponseDataBody{
+		Id:                         int(course.ID),
+		Authority:                  course.Authority,
+		TravelMode:                 course.TravelMode,
+		DateSpots:                  dateSpots,
+		NoDuplicatePrefectureNames: prefectureNames,
+		User:                       courseUser,
+	}, nil
+}
+
+// buildDateSpotReviewDataBody は DateSpotReview から DateSpotReviewDataBody を構築します。
+// Review.DateSpot が Preload 済みであることを前提とします。
+func buildDateSpotReviewDataBody(review *model.DateSpotReview) DateSpotReviewDataBody {
+	var rate float32
+	if review.Rate != nil {
+		rate = float32(*review.Rate)
+	}
+	var content string
+	if review.Content != nil {
+		content = *review.Content
+	}
+
+	var dateSpot DateSpotDataResponse
+	if review.DateSpot != nil {
+		dateSpot = newDateSpotData(review.DateSpot)
+	}
+
+	return DateSpotReviewDataBody{
+		Id:       int(review.ID),
+		Rate:     rate,
+		Content:  content,
+		DateSpot: dateSpot,
+	}
+}

--- a/internal/interface/openapi/users.go
+++ b/internal/interface/openapi/users.go
@@ -3,22 +3,23 @@ package openapi
 import (
 	"github.com/daisuke-harada/date-courses-go/internal/domain/master"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/oapi-codegen/runtime/types"
 )
 
 // UserResponseBody は UserResponseData の代替型です。
 // CourseResponseDataBody / DateSpotReviewDataBody を使うことで
 // OpeningTime / ClosingTime の nullable を正しく扱います。
 type UserResponseBody struct {
-	Admin           bool                    `json:"admin"`
+	Admin           bool                     `json:"admin"`
 	Courses         []CourseResponseDataBody `json:"courses"`
 	DateSpotReviews []DateSpotReviewDataBody `json:"date_spot_reviews"`
-	Email           string                  `json:"email"`
-	FollowerIds     []int                   `json:"followerIds"`
-	FollowingIds    []int                   `json:"followingIds"`
-	Gender          Gender                  `json:"gender"`
-	Id              int                     `json:"id"`
-	Image           ImageData               `json:"image"`
-	Name            string                  `json:"name"`
+	Email           string                   `json:"email"`
+	FollowerIds     []int                    `json:"followerIds"`
+	FollowingIds    []int                    `json:"followingIds"`
+	Gender          Gender                   `json:"gender"`
+	Id              int                      `json:"id"`
+	Image           ImageData                `json:"image"`
+	Name            string                   `json:"name"`
 }
 
 // CourseResponseDataBody は CourseResponseData の代替型です。
@@ -121,7 +122,7 @@ func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, erro
 		courseUser = UserData{
 			Id:     int(course.User.ID),
 			Name:   course.User.Name,
-			Email:  course.User.Email,
+			Email:  types.Email(course.User.Email),
 			Gender: gender,
 			Image:  ImageData{Url: course.User.Image},
 			Admin:  course.User.Admin,
@@ -161,4 +162,23 @@ func buildDateSpotReviewDataBody(review *model.DateSpotReview) DateSpotReviewDat
 		Content:  content,
 		DateSpot: dateSpot,
 	}
+}
+
+// NewGetUsersResponse は output.Users から []UserResponseBody を構築します。
+func NewGetUsersResponse(users []*model.UserWithRelations) ([]UserResponseBody, error) {
+	responses := make([]UserResponseBody, 0, len(users))
+	for _, uwr := range users {
+		resp, err := BuildUserResponseBody(
+			uwr.User,
+			uwr.FollowerIDs,
+			uwr.FollowingIDs,
+			uwr.Courses,
+			uwr.Reviews,
+		)
+		if err != nil {
+			return nil, err
+		}
+		responses = append(responses, resp)
+	}
+	return responses, nil
 }

--- a/internal/usecase/get_users.go
+++ b/internal/usecase/get_users.go
@@ -1,0 +1,97 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+// GetUsersInputPort はユーザー一覧取得ユースケースの入力ポートです。
+type GetUsersInputPort interface {
+	Execute(context.Context, GetUsersInput) (*GetUsersOutput, error)
+}
+
+type GetUsersInput struct {
+	Name *string
+}
+
+type GetUsersOutput struct {
+	Users []*UserWithRelations
+}
+
+// UserWithRelations はユーザーと関連データをまとめた中間型です。
+type UserWithRelations struct {
+	User         *model.User
+	FollowerIDs  []int
+	FollowingIDs []int
+	Courses      []*model.Course
+	Reviews      []*model.DateSpotReview
+}
+
+type GetUsersInteractor struct {
+	UserRepository          repository.UserRepository
+	CourseRepository        repository.CourseRepository
+	DateSpotReviewRepository repository.DateSpotReviewRepository
+}
+
+func NewGetUsersUsecase(
+	userRepository repository.UserRepository,
+	courseRepository repository.CourseRepository,
+	dateSpotReviewRepository repository.DateSpotReviewRepository,
+) GetUsersInputPort {
+	return &GetUsersInteractor{
+		UserRepository:          userRepository,
+		CourseRepository:        courseRepository,
+		DateSpotReviewRepository: dateSpotReviewRepository,
+	}
+}
+
+func (i *GetUsersInteractor) Execute(ctx context.Context, input GetUsersInput) (*GetUsersOutput, error) {
+	users, err := i.UserRepository.Search(ctx, input.Name)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	result := make([]*UserWithRelations, 0, len(users))
+	for _, user := range users {
+		uwr, err := i.buildUserWithRelations(ctx, user)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, uwr)
+	}
+
+	return &GetUsersOutput{Users: result}, nil
+}
+
+func (i *GetUsersInteractor) buildUserWithRelations(ctx context.Context, user *model.User) (*UserWithRelations, error) {
+	followerIDs, err := i.UserRepository.FindFollowerIDsByUserID(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	followingIDs, err := i.UserRepository.FindFollowingIDsByUserID(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	courses, err := i.CourseRepository.FindByUserID(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	reviews, err := i.DateSpotReviewRepository.FindByUserID(ctx, user.ID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	return &UserWithRelations{
+		User:         user,
+		FollowerIDs:  followerIDs,
+		FollowingIDs: followingIDs,
+		Courses:      courses,
+		Reviews:      reviews,
+	}, nil
+}

--- a/internal/usecase/get_users.go
+++ b/internal/usecase/get_users.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"sync"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
@@ -18,21 +19,12 @@ type GetUsersInput struct {
 }
 
 type GetUsersOutput struct {
-	Users []*UserWithRelations
-}
-
-// UserWithRelations はユーザーと関連データをまとめた中間型です。
-type UserWithRelations struct {
-	User         *model.User
-	FollowerIDs  []int
-	FollowingIDs []int
-	Courses      []*model.Course
-	Reviews      []*model.DateSpotReview
+	Users []*model.UserWithRelations
 }
 
 type GetUsersInteractor struct {
-	UserRepository          repository.UserRepository
-	CourseRepository        repository.CourseRepository
+	UserRepository           repository.UserRepository
+	CourseRepository         repository.CourseRepository
 	DateSpotReviewRepository repository.DateSpotReviewRepository
 }
 
@@ -42,8 +34,8 @@ func NewGetUsersUsecase(
 	dateSpotReviewRepository repository.DateSpotReviewRepository,
 ) GetUsersInputPort {
 	return &GetUsersInteractor{
-		UserRepository:          userRepository,
-		CourseRepository:        courseRepository,
+		UserRepository:           userRepository,
+		CourseRepository:         courseRepository,
 		DateSpotReviewRepository: dateSpotReviewRepository,
 	}
 }
@@ -54,40 +46,92 @@ func (i *GetUsersInteractor) Execute(ctx context.Context, input GetUsersInput) (
 		return nil, apperror.InternalServerError(err)
 	}
 
-	result := make([]*UserWithRelations, 0, len(users))
-	for _, user := range users {
-		uwr, err := i.buildUserWithRelations(ctx, user)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, uwr)
+	result := make([]*model.UserWithRelations, len(users))
+	errCh := make(chan error, len(users))
+	var wg sync.WaitGroup
+
+	for idx, user := range users {
+		wg.Add(1)
+		go func(idx int, user *model.User) {
+			defer wg.Done()
+			uwr, err := i.buildUserWithRelations(ctx, user)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			result[idx] = uwr
+		}(idx, user)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		return nil, err
 	}
 
 	return &GetUsersOutput{Users: result}, nil
 }
 
-func (i *GetUsersInteractor) buildUserWithRelations(ctx context.Context, user *model.User) (*UserWithRelations, error) {
-	followerIDs, err := i.UserRepository.FindFollowerIDsByUserID(ctx, user.ID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
+func (i *GetUsersInteractor) buildUserWithRelations(ctx context.Context, user *model.User) (*model.UserWithRelations, error) {
+	var (
+		followerIDs  []int
+		followingIDs []int
+		courses      []*model.Course
+		reviews      []*model.DateSpotReview
+	)
+
+	errCh := make(chan error, 4)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		followerIDs, err = i.UserRepository.FindFollowerIDsByUserID(ctx, user.ID)
+		if err != nil {
+			errCh <- apperror.InternalServerError(err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		followingIDs, err = i.UserRepository.FindFollowingIDsByUserID(ctx, user.ID)
+		if err != nil {
+			errCh <- apperror.InternalServerError(err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		courses, err = i.CourseRepository.FindByUserID(ctx, user.ID)
+		if err != nil {
+			errCh <- apperror.InternalServerError(err)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		reviews, err = i.DateSpotReviewRepository.FindByUserID(ctx, user.ID)
+		if err != nil {
+			errCh <- apperror.InternalServerError(err)
+		}
+	}()
+
+	wg.Wait()
+	close(errCh)
+
+	if err := <-errCh; err != nil {
+		return nil, err
 	}
 
-	followingIDs, err := i.UserRepository.FindFollowingIDsByUserID(ctx, user.ID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
-	courses, err := i.CourseRepository.FindByUserID(ctx, user.ID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
-	reviews, err := i.DateSpotReviewRepository.FindByUserID(ctx, user.ID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
-	return &UserWithRelations{
+	return &model.UserWithRelations{
 		User:         user,
 		FollowerIDs:  followerIDs,
 		FollowingIDs: followingIDs,


### PR DESCRIPTION
- Add Search, Update, Delete, FindFollowerIDs, FindFollowingIDs to UserRepository interface
- Add FindByUserID to CourseRepository and DateSpotReviewRepository interfaces
- Add FindFollowingsByUserID/FindFollowersByUserID to RelationshipRepository interface
- Implement all new repository methods in persistence layer with GORM
- Add DuringSpots association to Course model for Preload support
- Add GetUsersInteractor usecase with UserWithRelations aggregation
- Add UserResponseBody and related builder functions to openapi package
- Wire GetApiV1UsersHandler in DI container and handler.go