### PR TITLE
[#52] PUT /api/v1/date_spots/:id

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -36,6 +36,7 @@ func ProvideServices(ct *Container) {
 func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewGetDateSpotsUsecase)
 	ct.MustProvide(usecase.NewCreateDateSpotUsecase)
+	ct.MustProvide(usecase.NewUpdateDateSpotUsecase)
 	ct.MustProvide(usecase.NewSignupUsecase)
 	ct.MustProvide(usecase.NewLoginUsecase)
 	ct.MustProvide(usecase.NewGetUsersUsecase)

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -51,7 +51,9 @@ func NewHandler(container *di.Container) *Handler {
 			InputPort: di.MustInvoke[usecase.SignupInputPort](container),
 		},
 		PutApiV1DateSpotReviewsIdHandler: PutApiV1DateSpotReviewsIdHandler{},
-		PutApiV1DateSpotsIdHandler:       PutApiV1DateSpotsIdHandler{},
+		PutApiV1DateSpotsIdHandler: PutApiV1DateSpotsIdHandler{
+			InputPort: di.MustInvoke[usecase.UpdateDateSpotInputPort](container),
+		},
 		PutApiV1UsersIdHandler: PutApiV1UsersIdHandler{
 			InputPort: di.MustInvoke[usecase.UpdateUserInputPort](container),
 		},

--- a/internal/interface/handler/put_api_v1_date_spots_id.go
+++ b/internal/interface/handler/put_api_v1_date_spots_id.go
@@ -2,13 +2,50 @@ package handler
 
 import (
 	"net/http"
+	"time"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type PutApiV1DateSpotsIdHandler struct {}
+type PutApiV1DateSpotsIdHandler struct {
+	InputPort usecase.UpdateDateSpotInputPort
+}
 
-func (h *PutApiV1DateSpotsIdHandler) PutApiV1DateSpotsId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *PutApiV1DateSpotsIdHandler) PutApiV1DateSpotsId(ctx echo.Context, id int) error {
+	var req struct {
+		Name         string `form:"name" validate:"required"`
+		GenreID      int    `form:"genre_id" validate:"required"`
+		PrefectureID int    `form:"prefecture_id" validate:"required"`
+		CityName     string `form:"city_name" validate:"required"`
+		OpeningTime  *time.Time `form:"opening_time"`
+		ClosingTime  *time.Time `form:"closing_time"`
+		Image        *string    `form:"image"`
+	}
+
+	if err := ctx.Bind(&req); err != nil {
+		return apperror.UnprocessableEntity(err)
+	}
+
+	if err := ctx.Validate(&req); err != nil {
+		return apperror.UnprocessableEntity(err)
+	}
+
+	input := usecase.UpdateDateSpotInput{
+		DateSpotID:   uint(id),
+		Name:         req.Name,
+		GenreID:      req.GenreID,
+		PrefectureID: req.PrefectureID,
+		CityName:     req.CityName,
+		OpeningTime:  req.OpeningTime,
+		ClosingTime:  req.ClosingTime,
+		Image:        req.Image,
+	}
+
+	if err := h.InputPort.Execute(ctx.Request().Context(), input); err != nil {
+		return err
+	}
+
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
 }

--- a/internal/interface/handler/put_api_v1_date_spots_id_test.go
+++ b/internal/interface/handler/put_api_v1_date_spots_id_test.go
@@ -1,0 +1,107 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func validUpdateDateSpotForm() url.Values {
+	form := url.Values{}
+	form.Set("name", "更新東京タワー")
+	form.Set("genre_id", "2")
+	form.Set("prefecture_id", "13")
+	form.Set("city_name", "港区")
+	form.Set("opening_time", "2024-01-01T10:00:00Z")
+	form.Set("closing_time", "2024-01-01T20:00:00Z")
+	return form
+}
+
+func TestPutApiV1DateSpotsIdHandler(t *testing.T) {
+	t.Run("success_returns_200", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateDateSpotInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/date_spots/10", strings.NewReader(validUpdateDateSpotForm().Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("10")
+
+		h := handler.PutApiV1DateSpotsIdHandler{InputPort: mockPort}
+		err := h.PutApiV1DateSpotsId(ctx, 10)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_missing_name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateDateSpotInputPort(ctrl)
+
+		e := echo.New()
+		form := validUpdateDateSpotForm()
+		form.Del("name")
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/date_spots/10", strings.NewReader(form.Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("10")
+
+		h := handler.PutApiV1DateSpotsIdHandler{InputPort: mockPort}
+		err := h.PutApiV1DateSpotsId(ctx, 10)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_usecase_returns_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateDateSpotInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/date_spots/10", strings.NewReader(validUpdateDateSpotForm().Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("10")
+
+		h := handler.PutApiV1DateSpotsIdHandler{InputPort: mockPort}
+		err := h.PutApiV1DateSpotsId(ctx, 10)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/update_date_spot.go
+++ b/internal/usecase/update_date_spot.go
@@ -1,0 +1,57 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+// UpdateDateSpotInputPort はデートスポット更新ユースケースの入力ポートです。
+type UpdateDateSpotInputPort interface {
+	Execute(context.Context, UpdateDateSpotInput) error
+}
+
+// UpdateDateSpotInput はデートスポット更新の入力データです。
+type UpdateDateSpotInput struct {
+	DateSpotID   uint
+	Name         string
+	GenreID      int
+	PrefectureID int
+	CityName     string
+	OpeningTime  *time.Time
+	ClosingTime  *time.Time
+	Image        *string
+}
+
+type UpdateDateSpotInteractor struct {
+	DateSpotRepository repository.DateSpotRepository
+}
+
+func NewUpdateDateSpotUsecase(
+	dateSpotRepository repository.DateSpotRepository,
+) UpdateDateSpotInputPort {
+	return &UpdateDateSpotInteractor{
+		DateSpotRepository: dateSpotRepository,
+	}
+}
+
+func (i *UpdateDateSpotInteractor) Execute(ctx context.Context, input UpdateDateSpotInput) error {
+	dateSpot := &model.DateSpot{
+		Name:         input.Name,
+		GenreID:      &input.GenreID,
+		PrefectureID: &input.PrefectureID,
+		CityName:     input.CityName,
+		OpeningTime:  input.OpeningTime,
+		ClosingTime:  input.ClosingTime,
+		Image:        input.Image,
+	}
+
+	if err := i.DateSpotRepository.Update(ctx, input.DateSpotID, dateSpot); err != nil {
+		return apperror.InternalServerError(err)
+	}
+
+	return nil
+}

--- a/internal/usecase/update_date_spot_test.go
+++ b/internal/usecase/update_date_spot_test.go
@@ -1,0 +1,69 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repositorymock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUpdateDateSpotInteractor_Execute(t *testing.T) {
+	now := time.Now()
+
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+
+		dateSpotRepo := repositorymock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			Update(ctx, uint(10), gomock.Any()).
+			Return(nil)
+
+		interactor := usecase.NewUpdateDateSpotUsecase(dateSpotRepo)
+		err := interactor.Execute(ctx, usecase.UpdateDateSpotInput{
+			DateSpotID:   10,
+			Name:         "更新スポット",
+			GenreID:      2,
+			PrefectureID: 14,
+			CityName:     "新宿区",
+			OpeningTime:  &now,
+			ClosingTime:  &now,
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("error_repository_update_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+
+		dateSpotRepo := repositorymock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			Update(ctx, uint(10), gomock.Any()).
+			Return(errors.New("db error"))
+
+		interactor := usecase.NewUpdateDateSpotUsecase(dateSpotRepo)
+		err := interactor.Execute(ctx, usecase.UpdateDateSpotInput{
+			DateSpotID:   10,
+			Name:         "更新スポット",
+			GenreID:      2,
+			PrefectureID: 14,
+			CityName:     "新宿区",
+			OpeningTime:  &now,
+			ClosingTime:  &now,
+		})
+
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
- usecase テスト + 実装（update_date_spot）
- handler テスト + 実装（put_api_v1_date_spots_id）
- DI 登録

Closes #52

## Changes
- `internal/usecase/update_date_spot_test.go` - usecase テスト（正常系、エラー系）
- `internal/usecase/update_date_spot.go` - usecase 実装
- `internal/interface/handler/put_api_v1_date_spots_id_test.go` - handler テスト
- `internal/interface/handler/put_api_v1_date_spots_id.go` - handler 実装（既存のスタブを置き換え）
- `internal/interface/handler/handler.go` - DI 登録（PutApiV1DateSpotsIdHandler）
- `internal/di/infrastructure.go` - usecase DI 登録

## TDD Flow
✅ Red → Green → Refactor に従い実装完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)
