### PR TITLE
[#60] Implement DELETE /api/v1/relationships/:current_user_id/:other_user_id

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -47,6 +47,7 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewGetUserFollowingsUsecase)
 	ct.MustProvide(usecase.NewGetUserFollowersUsecase)
 	ct.MustProvide(usecase.NewCreateRelationshipUsecase)
+	ct.MustProvide(usecase.NewDeleteRelationshipUsecase)
 	ct.MustProvide(usecase.NewGetCoursesUsecase)
 	ct.MustProvide(usecase.NewGetCourseUsecase)
 }

--- a/internal/domain/repository/mock/relationship_repository.go
+++ b/internal/domain/repository/mock/relationship_repository.go
@@ -55,6 +55,20 @@ func (mr *MockRelationshipRepositoryMockRecorder) Create(ctx, relationship any) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRelationshipRepository)(nil).Create), ctx, relationship)
 }
 
+// DeleteByUserIDs mocks base method.
+func (m *MockRelationshipRepository) DeleteByUserIDs(ctx context.Context, userID uint, followID uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByUserIDs", ctx, userID, followID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByUserIDs indicates an expected call of DeleteByUserIDs.
+func (mr *MockRelationshipRepositoryMockRecorder) DeleteByUserIDs(ctx, userID, followID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByUserIDs", reflect.TypeOf((*MockRelationshipRepository)(nil).DeleteByUserIDs), ctx, userID, followID)
+}
+
 // FindFollowersByUserID mocks base method.
 func (m *MockRelationshipRepository) FindFollowersByUserID(ctx context.Context, userID uint) ([]*model.User, error) {
 	m.ctrl.T.Helper()

--- a/internal/domain/repository/relationship_repository.go
+++ b/internal/domain/repository/relationship_repository.go
@@ -10,4 +10,5 @@ type RelationshipRepository interface {
 	Create(ctx context.Context, relationship *model.Relationship) error
 	FindFollowingsByUserID(ctx context.Context, userID uint) ([]*model.User, error)
 	FindFollowersByUserID(ctx context.Context, userID uint) ([]*model.User, error)
+	DeleteByUserIDs(ctx context.Context, userID uint, followID uint) error
 }

--- a/internal/infrastructure/persistence/relationship_repository.go
+++ b/internal/infrastructure/persistence/relationship_repository.go
@@ -26,6 +26,17 @@ func (r *relationshipRepository) Create(ctx context.Context, relationship *model
 	return nil
 }
 
+// DeleteByUserIDs は user_id と follow_id の組み合わせに一致するレコードを削除します。
+func (r *relationshipRepository) DeleteByUserIDs(ctx context.Context, userID uint, followID uint) error {
+	if err := r.db.WithContext(ctx).
+		Where("user_id = ? AND follow_id = ?", userID, followID).
+		Delete(&model.Relationship{}).Error; err != nil {
+		slog.ErrorContext(ctx, "relationshipRepository.DeleteByUserIDs failed", "err", err)
+		return err
+	}
+	return nil
+}
+
 // FindFollowingsByUserID は指定ユーザーがフォローしているユーザー一覧（管理者除く）を返します。
 // Rails: user.followings.includes(...).non_admins に相当します。
 func (r *relationshipRepository) FindFollowingsByUserID(ctx context.Context, userID uint) ([]*model.User, error) {

--- a/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
+++ b/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
@@ -2,13 +2,22 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler struct {}
+type DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler struct {
+	InputPort usecase.DeleteRelationshipInputPort
+}
 
-func (h *DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler) DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx echo.Context, arg1 int , arg2 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler) DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx echo.Context, arg1 int, arg2 int) error {
+	_, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteRelationshipInput{
+		UserID:   uint(arg1),
+		FollowID: uint(arg2),
+	})
+	if err != nil {
+		return err
+	}
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
 }

--- a/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id_test.go
+++ b/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id_test.go
@@ -1,0 +1,56 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler(t *testing.T) {
+	t.Run("success_returns_200", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteRelationshipInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteRelationshipInput{UserID: 1, FollowID: 2}).
+			Return(&usecase.DeleteRelationshipOutput{}, nil)
+
+		ctx, rec := setupFormRequest(http.MethodDelete, "/api/v1/relationships/1/2", url.Values{})
+
+		h := handler.DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx, 1, 2)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteRelationshipInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		ctx, _ := setupFormRequest(http.MethodDelete, "/api/v1/relationships/1/2", url.Values{})
+
+		h := handler.DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx, 1, 2)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -7,12 +7,14 @@ import (
 
 func NewHandler(container *di.Container) *Handler {
 	return &Handler{
-		DeleteApiV1CoursesIdHandler:                             DeleteApiV1CoursesIdHandler{},
-		DeleteApiV1DateSpotReviewsIdHandler:                     DeleteApiV1DateSpotReviewsIdHandler{},
+		DeleteApiV1CoursesIdHandler:         DeleteApiV1CoursesIdHandler{},
+		DeleteApiV1DateSpotReviewsIdHandler: DeleteApiV1DateSpotReviewsIdHandler{},
 		DeleteApiV1DateSpotsIdHandler: DeleteApiV1DateSpotsIdHandler{
 			InputPort: di.MustInvoke[usecase.DeleteDateSpotInputPort](container),
 		},
-		DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler: DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler{},
+		DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler: DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler{
+			InputPort: di.MustInvoke[usecase.DeleteRelationshipInputPort](container),
+		},
 		DeleteApiV1UsersIdHandler: DeleteApiV1UsersIdHandler{
 			InputPort: di.MustInvoke[usecase.DeleteUserInputPort](container),
 		},

--- a/internal/usecase/delete_relationship.go
+++ b/internal/usecase/delete_relationship.go
@@ -1,0 +1,34 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type DeleteRelationshipInputPort interface {
+	Execute(context.Context, DeleteRelationshipInput) (*DeleteRelationshipOutput, error)
+}
+
+type DeleteRelationshipInput struct {
+	UserID   uint
+	FollowID uint
+}
+
+type DeleteRelationshipOutput struct{}
+
+type DeleteRelationshipInteractor struct {
+	RelationshipRepository repository.RelationshipRepository
+}
+
+func NewDeleteRelationshipUsecase(relationshipRepository repository.RelationshipRepository) DeleteRelationshipInputPort {
+	return &DeleteRelationshipInteractor{RelationshipRepository: relationshipRepository}
+}
+
+func (i *DeleteRelationshipInteractor) Execute(ctx context.Context, input DeleteRelationshipInput) (*DeleteRelationshipOutput, error) {
+	if err := i.RelationshipRepository.DeleteByUserIDs(ctx, input.UserID, input.FollowID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	return &DeleteRelationshipOutput{}, nil
+}

--- a/internal/usecase/delete_relationship_test.go
+++ b/internal/usecase/delete_relationship_test.go
@@ -1,0 +1,55 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteRelationshipInteractor_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		relationshipRepo := repomock.NewMockRelationshipRepository(ctrl)
+		relationshipRepo.EXPECT().
+			DeleteByUserIDs(ctx, uint(1), uint(2)).
+			Return(nil)
+
+		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
+			UserID:   1,
+			FollowID: 2,
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, output)
+	})
+
+	t.Run("error_repository_delete_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		relationshipRepo := repomock.NewMockRelationshipRepository(ctrl)
+		relationshipRepo.EXPECT().
+			DeleteByUserIDs(ctx, uint(1), uint(2)).
+			Return(errors.New("db error"))
+
+		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
+			UserID:   1,
+			FollowID: 2,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+}

--- a/internal/usecase/mock/delete_relationship.go
+++ b/internal/usecase/mock/delete_relationship.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockDeleteRelationshipInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeleteRelationshipInputPortMockRecorder
+}
+
+type MockDeleteRelationshipInputPortMockRecorder struct {
+	mock *MockDeleteRelationshipInputPort
+}
+
+func NewMockDeleteRelationshipInputPort(ctrl *gomock.Controller) *MockDeleteRelationshipInputPort {
+	mock := &MockDeleteRelationshipInputPort{ctrl: ctrl}
+	mock.recorder = &MockDeleteRelationshipInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockDeleteRelationshipInputPort) EXPECT() *MockDeleteRelationshipInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockDeleteRelationshipInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteRelationshipInput) (*usecase.DeleteRelationshipOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.DeleteRelationshipOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockDeleteRelationshipInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDeleteRelationshipInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #60

## 変更内容

- `internal/domain/repository/relationship_repository.go` — `DeleteByUserIDs` メソッドをインターフェースに追加
- `internal/domain/repository/mock/relationship_repository.go` — `DeleteByUserIDs` モックを追加
- `internal/infrastructure/persistence/relationship_repository.go` — `DeleteByUserIDs` の GORM 実装を追加（user_id + follow_id で WHERE 削除）
- `internal/usecase/delete_relationship.go` — `DeleteRelationshipInputPort` / `DeleteRelationshipInteractor` を実装
- `internal/usecase/delete_relationship_test.go` — success / error_repository_delete_failed の2ケースをテスト
- `internal/usecase/mock/delete_relationship.go` — `MockDeleteRelationshipInputPort` を追加
- `internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go` — ハンドラー実装（スタブを置き換え）
- `internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id_test.go` — success / error_usecase_returns_error の2ケースをテスト
- `internal/interface/handler/handler.go` — `DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler` に DI で InputPort を注入
- `internal/di/infrastructure.go` — `NewDeleteRelationshipUsecase` を `ProvideUsecases` に登録