### PR TITLE
[#53] Implement POST /api/v1/date_spot_reviews

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -50,4 +50,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewDeleteRelationshipUsecase)
 	ct.MustProvide(usecase.NewGetCoursesUsecase)
 	ct.MustProvide(usecase.NewGetCourseUsecase)
+	ct.MustProvide(usecase.NewCreateDateSpotReviewUsecase)
 }

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -44,8 +44,10 @@ func NewHandler(container *di.Container) *Handler {
 		GetApiV1UsersUserIdFollowingsHandler: GetApiV1UsersUserIdFollowingsHandler{
 			InputPort: di.MustInvoke[usecase.GetUserFollowingsInputPort](container),
 		},
-		PostApiV1CoursesHandler:         PostApiV1CoursesHandler{},
-		PostApiV1DateSpotReviewsHandler: PostApiV1DateSpotReviewsHandler{},
+		PostApiV1CoursesHandler: PostApiV1CoursesHandler{},
+		PostApiV1DateSpotReviewsHandler: PostApiV1DateSpotReviewsHandler{
+			InputPort: di.MustInvoke[usecase.CreateDateSpotReviewInputPort](container),
+		},
 		PostApiV1DateSpotsHandler: PostApiV1DateSpotsHandler{
 			InputPort: di.MustInvoke[usecase.CreateDateSpotInputPort](container),
 		},

--- a/internal/interface/handler/post_api_v1_date_spot_reviews.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews.go
@@ -2,13 +2,73 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type PostApiV1DateSpotReviewsHandler struct {}
+type PostApiV1DateSpotReviewsHandler struct {
+	InputPort usecase.CreateDateSpotReviewInputPort
+}
 
 func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Context) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+	var errs []string
+
+	// user_id (required)
+	userIDStr := ctx.FormValue("user_id")
+	if strings.TrimSpace(userIDStr) == "" {
+		errs = append(errs, "ユーザーIDを入力してください")
+	}
+	userID, userIDErr := strconv.Atoi(userIDStr)
+	if userIDErr != nil && strings.TrimSpace(userIDStr) != "" {
+		errs = append(errs, "ユーザーIDは整数で入力してください")
+	}
+
+	// date_spot_id (required)
+	dateSpotIDStr := ctx.FormValue("date_spot_id")
+	if strings.TrimSpace(dateSpotIDStr) == "" {
+		errs = append(errs, "デートスポットIDを入力してください")
+	}
+	dateSpotID, dateSpotIDErr := strconv.Atoi(dateSpotIDStr)
+	if dateSpotIDErr != nil && strings.TrimSpace(dateSpotIDStr) != "" {
+		errs = append(errs, "デートスポットIDは整数で入力してください")
+	}
+
+	if len(errs) > 0 {
+		return apperror.UnprocessableEntity(errs...)
+	}
+
+	// rate (optional)
+	var rate *float64
+	if rateStr := ctx.FormValue("rate"); strings.TrimSpace(rateStr) != "" {
+		r, err := strconv.ParseFloat(rateStr, 64)
+		if err != nil {
+			return apperror.UnprocessableEntity("評価は数値で入力してください")
+		}
+		rate = &r
+	}
+
+	// content (optional)
+	var content *string
+	if c := ctx.FormValue("content"); strings.TrimSpace(c) != "" {
+		content = &c
+	}
+
+	input := usecase.CreateDateSpotReviewInput{
+		UserID:     uint(userID),
+		DateSpotID: uint(dateSpotID),
+		Rate:       rate,
+		Content:    content,
+	}
+	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
+	if err != nil {
+		return err
+	}
+
+	return ctx.JSON(http.StatusCreated, map[string]interface{}{
+		"review_id": int(output.ReviewID),
+	})
 }

--- a/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
@@ -1,0 +1,108 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func validDateSpotReviewForm() url.Values {
+	form := url.Values{}
+	form.Set("user_id", "1")
+	form.Set("date_spot_id", "2")
+	form.Set("rate", "4.5")
+	form.Set("content", "とても良かった")
+	return form
+}
+
+func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
+	t.Run("success_returns_201_with_review_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.CreateDateSpotReviewOutput{ReviewID: 10}, nil)
+
+		ctx, rec := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", validDateSpotReviewForm())
+
+		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
+		err := h.PostApiV1DateSpotReviews(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, float64(10), resp["review_id"])
+	})
+
+	t.Run("error_missing_user_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+
+		form := validDateSpotReviewForm()
+		form.Del("user_id")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
+
+		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
+		err := h.PostApiV1DateSpotReviews(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_missing_date_spot_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+
+		form := validDateSpotReviewForm()
+		form.Del("date_spot_id")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
+
+		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
+		err := h.PostApiV1DateSpotReviews(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_usecase_returns_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", validDateSpotReviewForm())
+
+		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
+		err := h.PostApiV1DateSpotReviews(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/create_date_spot_review.go
+++ b/internal/usecase/create_date_spot_review.go
@@ -1,0 +1,45 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type CreateDateSpotReviewInputPort interface {
+	Execute(context.Context, CreateDateSpotReviewInput) (*CreateDateSpotReviewOutput, error)
+}
+
+type CreateDateSpotReviewInput struct {
+	UserID     uint
+	DateSpotID uint
+	Rate       *float64
+	Content    *string
+}
+
+type CreateDateSpotReviewOutput struct {
+	ReviewID uint
+}
+
+type CreateDateSpotReviewInteractor struct {
+	DateSpotReviewRepository repository.DateSpotReviewRepository
+}
+
+func NewCreateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) CreateDateSpotReviewInputPort {
+	return &CreateDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
+}
+
+func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input CreateDateSpotReviewInput) (*CreateDateSpotReviewOutput, error) {
+	review := &model.DateSpotReview{
+		UserID:     input.UserID,
+		DateSpotID: input.DateSpotID,
+		Rate:       input.Rate,
+		Content:    input.Content,
+	}
+	if err := i.DateSpotReviewRepository.Create(ctx, review); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	return &CreateDateSpotReviewOutput{ReviewID: review.ID}, nil
+}

--- a/internal/usecase/create_date_spot_review_test.go
+++ b/internal/usecase/create_date_spot_review_test.go
@@ -1,0 +1,64 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	rate := 4.5
+	content := "とても良かった"
+
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			Create(ctx, gomock.Any()).
+			DoAndReturn(func(_ context.Context, r *model.DateSpotReview) error {
+				r.ID = 10
+				return nil
+			})
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
+			UserID:     1,
+			DateSpotID: 2,
+			Rate:       &rate,
+			Content:    &content,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, uint(10), output.ReviewID)
+	})
+
+	t.Run("error_repository_create_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			Create(ctx, gomock.Any()).
+			Return(errors.New("db error"))
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
+			UserID:     1,
+			DateSpotID: 2,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+}

--- a/internal/usecase/mock/create_date_spot_review.go
+++ b/internal/usecase/mock/create_date_spot_review.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockCreateDateSpotReviewInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockCreateDateSpotReviewInputPortMockRecorder
+}
+
+type MockCreateDateSpotReviewInputPortMockRecorder struct {
+	mock *MockCreateDateSpotReviewInputPort
+}
+
+func NewMockCreateDateSpotReviewInputPort(ctrl *gomock.Controller) *MockCreateDateSpotReviewInputPort {
+	mock := &MockCreateDateSpotReviewInputPort{ctrl: ctrl}
+	mock.recorder = &MockCreateDateSpotReviewInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockCreateDateSpotReviewInputPort) EXPECT() *MockCreateDateSpotReviewInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockCreateDateSpotReviewInputPort) Execute(arg0 context.Context, arg1 usecase.CreateDateSpotReviewInput) (*usecase.CreateDateSpotReviewOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.CreateDateSpotReviewOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockCreateDateSpotReviewInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockCreateDateSpotReviewInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #53

## 変更内容

- `internal/usecase/create_date_spot_review.go` — `CreateDateSpotReviewInputPort` / `CreateDateSpotReviewInteractor` を実装（Rate・Content はオプション）
- `internal/usecase/create_date_spot_review_test.go` — success / error_repository_create_failed の2ケースをテスト
- `internal/usecase/mock/create_date_spot_review.go` — `MockCreateDateSpotReviewInputPort` を追加
- `internal/interface/handler/post_api_v1_date_spot_reviews.go` — ハンドラー実装（user_id・date_spot_id は必須、rate・content はオプション）
- `internal/interface/handler/post_api_v1_date_spot_reviews_test.go` — success / missing_user_id / missing_date_spot_id / error_usecase の4ケースをテスト
- `internal/interface/handler/handler.go` — `PostApiV1DateSpotReviewsHandler` に DI で InputPort を注入
- `internal/di/infrastructure.go` — `NewCreateDateSpotReviewUsecase` を `ProvideUsecases` に登録