### PR TITLE
[#54] Implement DELETE /api/v1/date_spot_reviews/:id

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -51,4 +51,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewGetCoursesUsecase)
 	ct.MustProvide(usecase.NewGetCourseUsecase)
 	ct.MustProvide(usecase.NewCreateDateSpotReviewUsecase)
+	ct.MustProvide(usecase.NewDeleteDateSpotReviewUsecase)
 }

--- a/internal/domain/repository/date_spot_review_repository.go
+++ b/internal/domain/repository/date_spot_review_repository.go
@@ -9,4 +9,5 @@ import (
 type DateSpotReviewRepository interface {
 	Create(ctx context.Context, review *model.DateSpotReview) error
 	FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error)
+	DeleteByID(ctx context.Context, id uint) error
 }

--- a/internal/domain/repository/mock/date_spot_review_repository.go
+++ b/internal/domain/repository/mock/date_spot_review_repository.go
@@ -55,6 +55,20 @@ func (mr *MockDateSpotReviewRepositoryMockRecorder) Create(ctx, review any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).Create), ctx, review)
 }
 
+// DeleteByID mocks base method.
+func (m *MockDateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByID", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByID indicates an expected call of DeleteByID.
+func (mr *MockDateSpotReviewRepositoryMockRecorder) DeleteByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).DeleteByID), ctx, id)
+}
+
 // FindByUserID mocks base method.
 func (m *MockDateSpotReviewRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error) {
 	m.ctrl.T.Helper()

--- a/internal/infrastructure/persistence/date_spot_review_repository.go
+++ b/internal/infrastructure/persistence/date_spot_review_repository.go
@@ -26,6 +26,15 @@ func (r *dateSpotReviewRepository) Create(ctx context.Context, review *model.Dat
 	return nil
 }
 
+// DeleteByID は指定 ID のレビューを削除します。
+func (r *dateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) error {
+	if err := r.db.WithContext(ctx).Delete(&model.DateSpotReview{}, id).Error; err != nil {
+		slog.ErrorContext(ctx, "dateSpotReviewRepository.DeleteByID failed", "err", err)
+		return err
+	}
+	return nil
+}
+
 // FindByUserID は指定ユーザーのレビュー一覧を DateSpot 込みで返します。
 func (r *dateSpotReviewRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error) {
 	var reviews []*model.DateSpotReview

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
@@ -2,13 +2,21 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type DeleteApiV1DateSpotReviewsIdHandler struct {}
+type DeleteApiV1DateSpotReviewsIdHandler struct {
+	InputPort usecase.DeleteDateSpotReviewInputPort
+}
 
-func (h *DeleteApiV1DateSpotReviewsIdHandler) DeleteApiV1DateSpotReviewsId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *DeleteApiV1DateSpotReviewsIdHandler) DeleteApiV1DateSpotReviewsId(ctx echo.Context, arg1 int) error {
+	_, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteDateSpotReviewInput{
+		ReviewID: uint(arg1),
+	})
+	if err != nil {
+		return err
+	}
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
 }

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
@@ -1,0 +1,56 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
+	t.Run("success_returns_200", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteDateSpotReviewInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteDateSpotReviewInput{ReviewID: 10}).
+			Return(&usecase.DeleteDateSpotReviewOutput{}, nil)
+
+		ctx, rec := setupFormRequest(http.MethodDelete, "/api/v1/date_spot_reviews/10", url.Values{})
+
+		h := handler.DeleteApiV1DateSpotReviewsIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1DateSpotReviewsId(ctx, 10)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteDateSpotReviewInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		ctx, _ := setupFormRequest(http.MethodDelete, "/api/v1/date_spot_reviews/10", url.Values{})
+
+		h := handler.DeleteApiV1DateSpotReviewsIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1DateSpotReviewsId(ctx, 10)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -7,8 +7,10 @@ import (
 
 func NewHandler(container *di.Container) *Handler {
 	return &Handler{
-		DeleteApiV1CoursesIdHandler:         DeleteApiV1CoursesIdHandler{},
-		DeleteApiV1DateSpotReviewsIdHandler: DeleteApiV1DateSpotReviewsIdHandler{},
+		DeleteApiV1CoursesIdHandler: DeleteApiV1CoursesIdHandler{},
+		DeleteApiV1DateSpotReviewsIdHandler: DeleteApiV1DateSpotReviewsIdHandler{
+			InputPort: di.MustInvoke[usecase.DeleteDateSpotReviewInputPort](container),
+		},
 		DeleteApiV1DateSpotsIdHandler: DeleteApiV1DateSpotsIdHandler{
 			InputPort: di.MustInvoke[usecase.DeleteDateSpotInputPort](container),
 		},

--- a/internal/interface/handler/post_api_v1_date_spot_reviews.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
@@ -15,45 +14,31 @@ type PostApiV1DateSpotReviewsHandler struct {
 }
 
 func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Context) error {
-	var errs []string
-
-	// user_id (required)
-	userIDStr := ctx.FormValue("user_id")
-	if strings.TrimSpace(userIDStr) == "" {
-		errs = append(errs, "ユーザーIDを入力してください")
-	}
-	userID, userIDErr := strconv.Atoi(userIDStr)
-	if userIDErr != nil && strings.TrimSpace(userIDStr) != "" {
-		errs = append(errs, "ユーザーIDは整数で入力してください")
+	// user_id: 型変換のみ。バリデーションは usecase.CreateDateSpotReviewInput.Validate() が担う
+	userID, err := strconv.Atoi(ctx.FormValue("user_id"))
+	if err != nil {
+		return apperror.BadRequest("user_id は整数で指定してください")
 	}
 
-	// date_spot_id (required)
-	dateSpotIDStr := ctx.FormValue("date_spot_id")
-	if strings.TrimSpace(dateSpotIDStr) == "" {
-		errs = append(errs, "デートスポットIDを入力してください")
-	}
-	dateSpotID, dateSpotIDErr := strconv.Atoi(dateSpotIDStr)
-	if dateSpotIDErr != nil && strings.TrimSpace(dateSpotIDStr) != "" {
-		errs = append(errs, "デートスポットIDは整数で入力してください")
-	}
-
-	if len(errs) > 0 {
-		return apperror.UnprocessableEntity(errs...)
+	// date_spot_id: 型変換のみ
+	dateSpotID, err := strconv.Atoi(ctx.FormValue("date_spot_id"))
+	if err != nil {
+		return apperror.BadRequest("date_spot_id は整数で指定してください")
 	}
 
 	// rate (optional)
 	var rate *float64
-	if rateStr := ctx.FormValue("rate"); strings.TrimSpace(rateStr) != "" {
+	if rateStr := ctx.FormValue("rate"); rateStr != "" {
 		r, err := strconv.ParseFloat(rateStr, 64)
 		if err != nil {
-			return apperror.UnprocessableEntity("評価は数値で入力してください")
+			return apperror.BadRequest("rate は数値で指定してください")
 		}
 		rate = &r
 	}
 
 	// content (optional)
 	var content *string
-	if c := ctx.FormValue("content"); strings.TrimSpace(c) != "" {
+	if c := ctx.FormValue("content"); c != "" {
 		content = &c
 	}
 

--- a/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
@@ -48,14 +48,16 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 		assert.Equal(t, float64(10), resp["review_id"])
 	})
 
-	t.Run("error_missing_user_id", func(t *testing.T) {
+	// user_id が空文字（フォーム未送信）は型変換失敗 → handler が BadRequest を返す
+	t.Run("error_bad_request_invalid_user_id", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+		// usecase は呼ばれない
 
 		form := validDateSpotReviewForm()
-		form.Del("user_id")
+		form.Set("user_id", "abc") // 非数値
 		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
 
 		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
@@ -64,17 +66,43 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 		assert.Error(t, err)
 		statusCode, _, _, ok := apperror.HTTPStatus(err)
 		assert.True(t, ok)
-		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
 	})
 
-	t.Run("error_missing_date_spot_id", func(t *testing.T) {
+	// date_spot_id が非数値は型変換失敗 → handler が BadRequest を返す
+	t.Run("error_bad_request_invalid_date_spot_id", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+		// usecase は呼ばれない
 
 		form := validDateSpotReviewForm()
-		form.Del("date_spot_id")
+		form.Set("date_spot_id", "xyz") // 非数値
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
+
+		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
+		err := h.PostApiV1DateSpotReviews(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+	})
+
+	// usecase が UnprocessableEntity を返すケース（Validate() 失敗など）
+	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.UnprocessableEntity("ユーザーIDを入力してください"))
+
+		// user_id=0 → 型変換は成功 → usecase が Validate() で失敗
+		form := validDateSpotReviewForm()
+		form.Set("user_id", "0")
 		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
 
 		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}

--- a/internal/usecase/create_date_spot_review.go
+++ b/internal/usecase/create_date_spot_review.go
@@ -19,6 +19,20 @@ type CreateDateSpotReviewInput struct {
 	Content    *string
 }
 
+func (i *CreateDateSpotReviewInput) Validate() error {
+	var errs []string
+	if i.UserID == 0 {
+		errs = append(errs, "ユーザーIDを入力してください")
+	}
+	if i.DateSpotID == 0 {
+		errs = append(errs, "デートスポットIDを入力してください")
+	}
+	if len(errs) > 0 {
+		return apperror.UnprocessableEntity(errs...)
+	}
+	return nil
+}
+
 type CreateDateSpotReviewOutput struct {
 	ReviewID uint
 }
@@ -32,6 +46,9 @@ func NewCreateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpot
 }
 
 func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input CreateDateSpotReviewInput) (*CreateDateSpotReviewOutput, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
 	review := &model.DateSpotReview{
 		UserID:     input.UserID,
 		DateSpotID: input.DateSpotID,

--- a/internal/usecase/create_date_spot_review_test.go
+++ b/internal/usecase/create_date_spot_review_test.go
@@ -3,8 +3,10 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
@@ -41,6 +43,46 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, uint(10), output.ReviewID)
+	})
+
+	t.Run("error_validation_missing_user_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		// リポジトリは呼ばれない
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
+			UserID:     0,
+			DateSpotID: 2,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_validation_missing_date_spot_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		// リポジトリは呼ばれない
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
+			UserID:     1,
+			DateSpotID: 0,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	})
 
 	t.Run("error_repository_create_failed", func(t *testing.T) {

--- a/internal/usecase/delete_date_spot_review.go
+++ b/internal/usecase/delete_date_spot_review.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type DeleteDateSpotReviewInputPort interface {
+	Execute(context.Context, DeleteDateSpotReviewInput) (*DeleteDateSpotReviewOutput, error)
+}
+
+type DeleteDateSpotReviewInput struct {
+	ReviewID uint
+}
+
+type DeleteDateSpotReviewOutput struct{}
+
+type DeleteDateSpotReviewInteractor struct {
+	DateSpotReviewRepository repository.DateSpotReviewRepository
+}
+
+func NewDeleteDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) DeleteDateSpotReviewInputPort {
+	return &DeleteDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
+}
+
+func (i *DeleteDateSpotReviewInteractor) Execute(ctx context.Context, input DeleteDateSpotReviewInput) (*DeleteDateSpotReviewOutput, error) {
+	if err := i.DateSpotReviewRepository.DeleteByID(ctx, input.ReviewID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	return &DeleteDateSpotReviewOutput{}, nil
+}

--- a/internal/usecase/delete_date_spot_review_test.go
+++ b/internal/usecase/delete_date_spot_review_test.go
@@ -1,0 +1,49 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			DeleteByID(ctx, uint(10)).
+			Return(nil)
+
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
+
+		require.NoError(t, err)
+		assert.NotNil(t, output)
+	})
+
+	t.Run("error_repository_delete_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			DeleteByID(ctx, uint(10)).
+			Return(errors.New("db error"))
+
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+}

--- a/internal/usecase/mock/delete_date_spot_review.go
+++ b/internal/usecase/mock/delete_date_spot_review.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockDeleteDateSpotReviewInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeleteDateSpotReviewInputPortMockRecorder
+}
+
+type MockDeleteDateSpotReviewInputPortMockRecorder struct {
+	mock *MockDeleteDateSpotReviewInputPort
+}
+
+func NewMockDeleteDateSpotReviewInputPort(ctrl *gomock.Controller) *MockDeleteDateSpotReviewInputPort {
+	mock := &MockDeleteDateSpotReviewInputPort{ctrl: ctrl}
+	mock.recorder = &MockDeleteDateSpotReviewInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockDeleteDateSpotReviewInputPort) EXPECT() *MockDeleteDateSpotReviewInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockDeleteDateSpotReviewInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteDateSpotReviewInput) (*usecase.DeleteDateSpotReviewOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.DeleteDateSpotReviewOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockDeleteDateSpotReviewInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDeleteDateSpotReviewInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #54

## 変更内容

- `internal/domain/repository/date_spot_review_repository.go` — `DeleteByID` メソッドをインターフェースに追加
- `internal/domain/repository/mock/date_spot_review_repository.go` — `DeleteByID` モックを追加
- `internal/infrastructure/persistence/date_spot_review_repository.go` — `DeleteByID` の GORM 実装を追加
- `internal/usecase/delete_date_spot_review.go` — `DeleteDateSpotReviewInputPort` / `DeleteDateSpotReviewInteractor` を実装
- `internal/usecase/delete_date_spot_review_test.go` — success / error_repository_delete_failed の2ケースをテスト
- `internal/usecase/mock/delete_date_spot_review.go` — `MockDeleteDateSpotReviewInputPort` を追加
- `internal/interface/handler/delete_api_v1_date_spot_reviews_id.go` — ハンドラー実装（スタブを置き換え）
- `internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go` — success / error_usecase の2ケースをテスト
- `internal/interface/handler/handler.go` — `DeleteApiV1DateSpotReviewsIdHandler` に DI で InputPort を注入
- `internal/di/infrastructure.go` — `NewDeleteDateSpotReviewUsecase` を `ProvideUsecases` に登録