### PR TITLE
[#56] POST /api/v1/courses 実装

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -53,4 +53,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewCreateDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewDeleteDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewUpdateDateSpotReviewUsecase)
+	ct.MustProvide(usecase.NewCreateCourseUsecase)
 }

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -46,7 +46,9 @@ func NewHandler(container *di.Container) *Handler {
 		GetApiV1UsersUserIdFollowingsHandler: GetApiV1UsersUserIdFollowingsHandler{
 			InputPort: di.MustInvoke[usecase.GetUserFollowingsInputPort](container),
 		},
-		PostApiV1CoursesHandler: PostApiV1CoursesHandler{},
+		PostApiV1CoursesHandler: PostApiV1CoursesHandler{
+			InputPort: di.MustInvoke[usecase.CreateCourseInputPort](container),
+		},
 		PostApiV1DateSpotReviewsHandler: PostApiV1DateSpotReviewsHandler{
 			InputPort: di.MustInvoke[usecase.CreateDateSpotReviewInputPort](container),
 		},

--- a/internal/interface/handler/post_api_v1_courses.go
+++ b/internal/interface/handler/post_api_v1_courses.go
@@ -2,13 +2,46 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type PostApiV1CoursesHandler struct {}
+type PostApiV1CoursesHandler struct {
+	InputPort usecase.CreateCourseInputPort
+}
 
 func (h *PostApiV1CoursesHandler) PostApiV1Courses(ctx echo.Context) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+	userID, err := strconv.Atoi(ctx.FormValue("user_id"))
+	if err != nil {
+		return apperror.BadRequest("user_id は整数で指定してください")
+	}
+
+	// ctx.FormValue 呼び出し時点で ParseForm 済みなので Form マップを直接参照できる
+	dateSpotIDStrs := ctx.Request().Form["date_spots[]"]
+	var dateSpotIDs []uint
+	for _, s := range dateSpotIDStrs {
+		id, err := strconv.Atoi(s)
+		if err != nil {
+			return apperror.BadRequest("date_spots[] は整数で指定してください")
+		}
+		dateSpotIDs = append(dateSpotIDs, uint(id))
+	}
+
+	travelMode := ctx.FormValue("travel_mode")
+	authority := ctx.FormValue("authority")
+
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.CreateCourseInput{
+		UserID:      uint(userID),
+		DateSpotIDs: dateSpotIDs,
+		TravelMode:  travelMode,
+		Authority:   authority,
+	})
+	if err != nil {
+		return err
+	}
+
+	return ctx.JSON(http.StatusCreated, map[string]int{"course_id": int(output.CourseID)})
 }

--- a/internal/interface/handler/post_api_v1_courses_test.go
+++ b/internal/interface/handler/post_api_v1_courses_test.go
@@ -1,0 +1,144 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPostApiV1CoursesHandler(t *testing.T) {
+	t.Run("success_returns_201_with_course_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.CreateCourseInput{
+				UserID:      1,
+				DateSpotIDs: []uint{10, 20},
+				TravelMode:  "DRIVING",
+				Authority:   "公開",
+			}).
+			Return(&usecase.CreateCourseOutput{CourseID: 5}, nil)
+
+		form := url.Values{}
+		form.Set("user_id", "1")
+		form.Add("date_spots[]", "10")
+		form.Add("date_spots[]", "20")
+		form.Set("travel_mode", "DRIVING")
+		form.Set("authority", "公開")
+		ctx, rec := setupFormRequest(http.MethodPost, "/api/v1/courses", form)
+
+		h := handler.PostApiV1CoursesHandler{InputPort: mockPort}
+		err := h.PostApiV1Courses(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, float64(5), resp["course_id"])
+	})
+
+	t.Run("error_bad_request_invalid_user_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateCourseInputPort(ctrl)
+
+		form := url.Values{}
+		form.Set("user_id", "abc")
+		form.Add("date_spots[]", "10")
+		form.Set("travel_mode", "DRIVING")
+		form.Set("authority", "公開")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/courses", form)
+
+		h := handler.PostApiV1CoursesHandler{InputPort: mockPort}
+		err := h.PostApiV1Courses(ctx)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+	})
+
+	t.Run("error_bad_request_invalid_date_spot_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateCourseInputPort(ctrl)
+
+		form := url.Values{}
+		form.Set("user_id", "1")
+		form.Add("date_spots[]", "abc")
+		form.Set("travel_mode", "DRIVING")
+		form.Set("authority", "公開")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/courses", form)
+
+		h := handler.PostApiV1CoursesHandler{InputPort: mockPort}
+		err := h.PostApiV1Courses(ctx)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+	})
+
+	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.UnprocessableEntity("デートスポットを1件以上入力してください"))
+
+		form := url.Values{}
+		form.Set("user_id", "1")
+		form.Set("travel_mode", "DRIVING")
+		form.Set("authority", "公開")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/courses", form)
+
+		h := handler.PostApiV1CoursesHandler{InputPort: mockPort}
+		err := h.PostApiV1Courses(ctx)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockCreateCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(nil))
+
+		form := url.Values{}
+		form.Set("user_id", "1")
+		form.Add("date_spots[]", "10")
+		form.Set("travel_mode", "DRIVING")
+		form.Set("authority", "公開")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/courses", form)
+
+		h := handler.PostApiV1CoursesHandler{InputPort: mockPort}
+		err := h.PostApiV1Courses(ctx)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/create_course.go
+++ b/internal/usecase/create_course.go
@@ -1,0 +1,85 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type CreateCourseInputPort interface {
+	Execute(context.Context, CreateCourseInput) (*CreateCourseOutput, error)
+}
+
+type CreateCourseInput struct {
+	UserID      uint
+	DateSpotIDs []uint
+	TravelMode  string
+	Authority   string
+}
+
+func (i *CreateCourseInput) Validate() error {
+	var errs []string
+	if i.UserID == 0 {
+		errs = append(errs, "ユーザーIDを入力してください")
+	}
+	if len(i.DateSpotIDs) == 0 {
+		errs = append(errs, "デートスポットを1件以上入力してください")
+	}
+	validTravelModes := map[string]bool{"DRIVING": true, "WALKING": true}
+	if !validTravelModes[i.TravelMode] {
+		errs = append(errs, "移動手段はDRIVINGまたはWALKINGを指定してください")
+	}
+	validAuthorities := map[string]bool{"公開": true, "非公開": true}
+	if !validAuthorities[i.Authority] {
+		errs = append(errs, "公開設定は公開または非公開を指定してください")
+	}
+	if len(errs) > 0 {
+		return apperror.UnprocessableEntity(errs...)
+	}
+	return nil
+}
+
+type CreateCourseOutput struct {
+	CourseID uint
+}
+
+type CreateCourseInteractor struct {
+	CourseRepository     repository.CourseRepository
+	DuringSpotRepository repository.DuringSpotRepository
+}
+
+func NewCreateCourseUsecase(
+	courseRepo repository.CourseRepository,
+	duringSpotRepo repository.DuringSpotRepository,
+) CreateCourseInputPort {
+	return &CreateCourseInteractor{
+		CourseRepository:     courseRepo,
+		DuringSpotRepository: duringSpotRepo,
+	}
+}
+
+func (i *CreateCourseInteractor) Execute(ctx context.Context, input CreateCourseInput) (*CreateCourseOutput, error) {
+	if err := input.Validate(); err != nil {
+		return nil, err
+	}
+	course := &model.Course{
+		UserID:     input.UserID,
+		TravelMode: input.TravelMode,
+		Authority:  input.Authority,
+	}
+	if err := i.CourseRepository.Create(ctx, course); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	for _, dateSpotID := range input.DateSpotIDs {
+		duringSpot := &model.DuringSpot{
+			CourseID:   course.ID,
+			DateSpotID: dateSpotID,
+		}
+		if err := i.DuringSpotRepository.Create(ctx, duringSpot); err != nil {
+			return nil, apperror.InternalServerError(err)
+		}
+	}
+	return &CreateCourseOutput{CourseID: course.ID}, nil
+}

--- a/internal/usecase/create_course_test.go
+++ b/internal/usecase/create_course_test.go
@@ -1,0 +1,190 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateCourseUsecase(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		mockCourseRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, course *model.Course) error {
+				course.ID = 10
+				return nil
+			})
+		mockDuringSpotRepo.EXPECT().
+			Create(gomock.Any(), &model.DuringSpot{CourseID: 10, DateSpotID: 1}).
+			Return(nil)
+		mockDuringSpotRepo.EXPECT().
+			Create(gomock.Any(), &model.DuringSpot{CourseID: 10, DateSpotID: 2}).
+			Return(nil)
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		out, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{1, 2},
+			TravelMode:  "DRIVING",
+			Authority:   "公開",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, uint(10), out.CourseID)
+	})
+
+	t.Run("error_validation_missing_user_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      0,
+			DateSpotIDs: []uint{1},
+			TravelMode:  "DRIVING",
+			Authority:   "公開",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_validation_no_date_spots", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{},
+			TravelMode:  "DRIVING",
+			Authority:   "公開",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_validation_invalid_travel_mode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{1},
+			TravelMode:  "FLYING",
+			Authority:   "公開",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_validation_invalid_authority", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{1},
+			TravelMode:  "DRIVING",
+			Authority:   "未設定",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_course_repository_create_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		mockCourseRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			Return(errors.New("db error"))
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{1},
+			TravelMode:  "DRIVING",
+			Authority:   "公開",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+
+	t.Run("error_during_spot_repository_create_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockDuringSpotRepo := repomock.NewMockDuringSpotRepository(ctrl)
+
+		mockCourseRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, course *model.Course) error {
+				course.ID = 10
+				return nil
+			})
+		mockDuringSpotRepo.EXPECT().
+			Create(gomock.Any(), gomock.Any()).
+			Return(errors.New("db error"))
+
+		uc := usecase.NewCreateCourseUsecase(mockCourseRepo, mockDuringSpotRepo)
+		_, err := uc.Execute(context.Background(), usecase.CreateCourseInput{
+			UserID:      1,
+			DateSpotIDs: []uint{1},
+			TravelMode:  "DRIVING",
+			Authority:   "公開",
+		})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/mock/create_course.go
+++ b/internal/usecase/mock/create_course.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockCreateCourseInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockCreateCourseInputPortMockRecorder
+}
+
+type MockCreateCourseInputPortMockRecorder struct {
+	mock *MockCreateCourseInputPort
+}
+
+func NewMockCreateCourseInputPort(ctrl *gomock.Controller) *MockCreateCourseInputPort {
+	mock := &MockCreateCourseInputPort{ctrl: ctrl}
+	mock.recorder = &MockCreateCourseInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockCreateCourseInputPort) EXPECT() *MockCreateCourseInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockCreateCourseInputPort) Execute(arg0 context.Context, arg1 usecase.CreateCourseInput) (*usecase.CreateCourseOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.CreateCourseOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockCreateCourseInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockCreateCourseInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #56\n\n## 変更内容\n\n- `CreateCourseInput` に `Validate()` を実装（UserID=0・DateSpotIDs 空・TravelMode/Authority 不正値 → 422）\n- `CreateCourseUsecase`: Course 作成後、各 DateSpotID に対して DuringSpot を順次作成\n- `MockCreateCourseInputPort` 追加\n- `PostApiV1CoursesHandler` 実装（user_id 型変換失敗 → 400、date_spots[] 各要素型変換失敗 → 400）\n- handler.go / infrastructure.go に DI 登録\n\n## テスト\n\n- usecase: success / error_validation_missing_user_id / error_validation_no_date_spots / error_validation_invalid_travel_mode / error_validation_invalid_authority / error_course_repository_create_failed / error_during_spot_repository_create_failed\n- handler: success_returns_201_with_course_id / error_bad_request_invalid_user_id / error_bad_request_invalid_date_spot_id / error_usecase_returns_unprocessable_entity / error_usecase_returns_internal_server_error\n