### PR TITLE
[#57] DELETE /api/v1/courses/:id 実装

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -54,4 +54,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewDeleteDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewUpdateDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewCreateCourseUsecase)
+	ct.MustProvide(usecase.NewDeleteCourseUsecase)
 }

--- a/internal/domain/repository/course_repository.go
+++ b/internal/domain/repository/course_repository.go
@@ -11,4 +11,5 @@ type CourseRepository interface {
 	FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error)
 	FindAll(ctx context.Context) ([]*model.Course, error)
 	FindByID(ctx context.Context, id uint) (*model.Course, error)
+	DeleteByID(ctx context.Context, id uint) error
 }

--- a/internal/domain/repository/mock/course_repository.go
+++ b/internal/domain/repository/mock/course_repository.go
@@ -55,6 +55,20 @@ func (mr *MockCourseRepositoryMockRecorder) Create(ctx, course any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCourseRepository)(nil).Create), ctx, course)
 }
 
+// DeleteByID mocks base method.
+func (m *MockCourseRepository) DeleteByID(ctx context.Context, id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByID", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByID indicates an expected call of DeleteByID.
+func (mr *MockCourseRepositoryMockRecorder) DeleteByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockCourseRepository)(nil).DeleteByID), ctx, id)
+}
+
 // FindByUserID mocks base method.
 func (m *MockCourseRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error) {
 	m.ctrl.T.Helper()

--- a/internal/infrastructure/persistence/course_repository.go
+++ b/internal/infrastructure/persistence/course_repository.go
@@ -65,3 +65,12 @@ func (r *courseRepository) FindByID(ctx context.Context, id uint) (*model.Course
 	}
 	return &course, nil
 }
+
+// DeleteByID は指定IDのコースを削除します。
+func (r *courseRepository) DeleteByID(ctx context.Context, id uint) error {
+	if err := r.db.WithContext(ctx).Delete(&model.Course{}, id).Error; err != nil {
+		slog.ErrorContext(ctx, "courseRepository.DeleteByID failed", "err", err)
+		return err
+	}
+	return nil
+}

--- a/internal/interface/handler/delete_api_v1_courses_id.go
+++ b/internal/interface/handler/delete_api_v1_courses_id.go
@@ -2,13 +2,21 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type DeleteApiV1CoursesIdHandler struct {}
+type DeleteApiV1CoursesIdHandler struct {
+	InputPort usecase.DeleteCourseInputPort
+}
 
-func (h *DeleteApiV1CoursesIdHandler) DeleteApiV1CoursesId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *DeleteApiV1CoursesIdHandler) DeleteApiV1CoursesId(ctx echo.Context, arg1 int) error {
+	_, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteCourseInput{
+		CourseID: uint(arg1),
+	})
+	if err != nil {
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/interface/handler/delete_api_v1_courses_id_test.go
+++ b/internal/interface/handler/delete_api_v1_courses_id_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteApiV1CoursesIdHandler(t *testing.T) {
+	t.Run("success_returns_204", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteCourseInput{CourseID: 1}).
+			Return(&usecase.DeleteCourseOutput{}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1CoursesIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1CoursesId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteCourseInput{CourseID: 1}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1CoursesIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1CoursesId(ctx, 1)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -7,7 +7,9 @@ import (
 
 func NewHandler(container *di.Container) *Handler {
 	return &Handler{
-		DeleteApiV1CoursesIdHandler: DeleteApiV1CoursesIdHandler{},
+		DeleteApiV1CoursesIdHandler: DeleteApiV1CoursesIdHandler{
+			InputPort: di.MustInvoke[usecase.DeleteCourseInputPort](container),
+		},
 		DeleteApiV1DateSpotReviewsIdHandler: DeleteApiV1DateSpotReviewsIdHandler{
 			InputPort: di.MustInvoke[usecase.DeleteDateSpotReviewInputPort](container),
 		},

--- a/internal/usecase/delete_course.go
+++ b/internal/usecase/delete_course.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type DeleteCourseInputPort interface {
+	Execute(context.Context, DeleteCourseInput) (*DeleteCourseOutput, error)
+}
+
+type DeleteCourseInput struct {
+	CourseID uint
+}
+
+type DeleteCourseOutput struct{}
+
+type DeleteCourseInteractor struct {
+	CourseRepository repository.CourseRepository
+}
+
+func NewDeleteCourseUsecase(courseRepository repository.CourseRepository) DeleteCourseInputPort {
+	return &DeleteCourseInteractor{CourseRepository: courseRepository}
+}
+
+func (i *DeleteCourseInteractor) Execute(ctx context.Context, input DeleteCourseInput) (*DeleteCourseOutput, error) {
+	if err := i.CourseRepository.DeleteByID(ctx, input.CourseID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	return &DeleteCourseOutput{}, nil
+}

--- a/internal/usecase/delete_course_test.go
+++ b/internal/usecase/delete_course_test.go
@@ -1,0 +1,50 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteCourseUsecase(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockCourseRepo.EXPECT().
+			DeleteByID(gomock.Any(), uint(1)).
+			Return(nil)
+
+		uc := usecase.NewDeleteCourseUsecase(mockCourseRepo)
+		_, err := uc.Execute(context.Background(), usecase.DeleteCourseInput{CourseID: 1})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("error_repository_delete_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockCourseRepo.EXPECT().
+			DeleteByID(gomock.Any(), uint(1)).
+			Return(errors.New("db error"))
+
+		uc := usecase.NewDeleteCourseUsecase(mockCourseRepo)
+		_, err := uc.Execute(context.Background(), usecase.DeleteCourseInput{CourseID: 1})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/mock/delete_course.go
+++ b/internal/usecase/mock/delete_course.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockDeleteCourseInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeleteCourseInputPortMockRecorder
+}
+
+type MockDeleteCourseInputPortMockRecorder struct {
+	mock *MockDeleteCourseInputPort
+}
+
+func NewMockDeleteCourseInputPort(ctrl *gomock.Controller) *MockDeleteCourseInputPort {
+	mock := &MockDeleteCourseInputPort{ctrl: ctrl}
+	mock.recorder = &MockDeleteCourseInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockDeleteCourseInputPort) EXPECT() *MockDeleteCourseInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockDeleteCourseInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteCourseInput) (*usecase.DeleteCourseOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.DeleteCourseOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockDeleteCourseInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDeleteCourseInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #57\n\n## 変更内容\n\n- `CourseRepository` に `DeleteByID` を追加（interface / mock / persistence）\n- `DeleteCourseUsecase` + `MockDeleteCourseInputPort` 実装\n- `DeleteApiV1CoursesIdHandler` 実装（204 No Content を返す）\n- handler.go / infrastructure.go に DI 登録\n\n## テスト\n\n- usecase: success / error_repository_delete_failed\n- handler: success_returns_204 / error_usecase_returns_internal_server_error\n\n## Rails 対応\n\nRails `CoursesController#destroy` は `@course.destroy` → `status: :no_content` と同じ挙動。\n