### PR TITLE
[#61/#62/#63] GET /api/v1/top, /prefectures/:id, /genres/:id 実装

### DIFF
--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -54,4 +54,5 @@ func ProvideUsecases(ct *Container) {
 	ct.MustProvide(usecase.NewDeleteDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewUpdateDateSpotReviewUsecase)
 	ct.MustProvide(usecase.NewCreateCourseUsecase)
+	ct.MustProvide(usecase.NewDeleteCourseUsecase)
 }

--- a/internal/domain/repository/course_repository.go
+++ b/internal/domain/repository/course_repository.go
@@ -11,4 +11,5 @@ type CourseRepository interface {
 	FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error)
 	FindAll(ctx context.Context) ([]*model.Course, error)
 	FindByID(ctx context.Context, id uint) (*model.Course, error)
+	DeleteByID(ctx context.Context, id uint) error
 }

--- a/internal/domain/repository/mock/course_repository.go
+++ b/internal/domain/repository/mock/course_repository.go
@@ -55,6 +55,20 @@ func (mr *MockCourseRepositoryMockRecorder) Create(ctx, course any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCourseRepository)(nil).Create), ctx, course)
 }
 
+// DeleteByID mocks base method.
+func (m *MockCourseRepository) DeleteByID(ctx context.Context, id uint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByID", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByID indicates an expected call of DeleteByID.
+func (mr *MockCourseRepositoryMockRecorder) DeleteByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockCourseRepository)(nil).DeleteByID), ctx, id)
+}
+
 // FindByUserID mocks base method.
 func (m *MockCourseRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error) {
 	m.ctrl.T.Helper()

--- a/internal/infrastructure/persistence/course_repository.go
+++ b/internal/infrastructure/persistence/course_repository.go
@@ -65,3 +65,12 @@ func (r *courseRepository) FindByID(ctx context.Context, id uint) (*model.Course
 	}
 	return &course, nil
 }
+
+// DeleteByID は指定IDのコースを削除します。
+func (r *courseRepository) DeleteByID(ctx context.Context, id uint) error {
+	if err := r.db.WithContext(ctx).Delete(&model.Course{}, id).Error; err != nil {
+		slog.ErrorContext(ctx, "courseRepository.DeleteByID failed", "err", err)
+		return err
+	}
+	return nil
+}

--- a/internal/interface/handler/delete_api_v1_courses_id.go
+++ b/internal/interface/handler/delete_api_v1_courses_id.go
@@ -2,13 +2,21 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type DeleteApiV1CoursesIdHandler struct {}
+type DeleteApiV1CoursesIdHandler struct {
+	InputPort usecase.DeleteCourseInputPort
+}
 
-func (h *DeleteApiV1CoursesIdHandler) DeleteApiV1CoursesId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *DeleteApiV1CoursesIdHandler) DeleteApiV1CoursesId(ctx echo.Context, arg1 int) error {
+	_, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteCourseInput{
+		CourseID: uint(arg1),
+	})
+	if err != nil {
+		return err
+	}
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/internal/interface/handler/delete_api_v1_courses_id_test.go
+++ b/internal/interface/handler/delete_api_v1_courses_id_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteApiV1CoursesIdHandler(t *testing.T) {
+	t.Run("success_returns_204", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteCourseInput{CourseID: 1}).
+			Return(&usecase.DeleteCourseOutput{}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1CoursesIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1CoursesId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteCourseInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteCourseInput{CourseID: 1}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1CoursesIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1CoursesId(ctx, 1)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_genres_id.go
+++ b/internal/interface/handler/get_api_v1_genres_id.go
@@ -2,13 +2,25 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type GetApiV1GenresIdHandler struct {}
+type GetApiV1GenresIdHandler struct {
+	InputPort usecase.GetDateSpotsInputPort
+}
 
-func (h *GetApiV1GenresIdHandler) GetApiV1GenresId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *GetApiV1GenresIdHandler) GetApiV1GenresId(ctx echo.Context, arg1 int) error {
+	genreID := arg1
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.GetDateSpotsInput{
+		GenreID: &genreID,
+	})
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{
+		"address_and_date_spots": openapi.NewDateSpotsResponse(output.DateSpots),
+	})
 }

--- a/internal/interface/handler/get_api_v1_genres_id_test.go
+++ b/internal/interface/handler/get_api_v1_genres_id_test.go
@@ -1,0 +1,70 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1GenresIdHandler(t *testing.T) {
+	t.Run("success_returns_200_with_address_and_date_spots", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		genreID := 2
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{GenreID: &genreID}).
+			Return(&usecase.GetDateSpotsOutput{DateSpots: []*model.DateSpot{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/genres/2", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1GenresIdHandler{InputPort: mockPort}
+		err := h.GetApiV1GenresId(ctx, 2)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Contains(t, resp, "address_and_date_spots")
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		genreID := 2
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{GenreID: &genreID}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/genres/2", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1GenresIdHandler{InputPort: mockPort}
+		err := h.GetApiV1GenresId(ctx, 2)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_prefectures_id.go
+++ b/internal/interface/handler/get_api_v1_prefectures_id.go
@@ -2,13 +2,23 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type GetApiV1PrefecturesIdHandler struct {}
+type GetApiV1PrefecturesIdHandler struct {
+	InputPort usecase.GetDateSpotsInputPort
+}
 
-func (h *GetApiV1PrefecturesIdHandler) GetApiV1PrefecturesId(ctx echo.Context, arg1 int ) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+func (h *GetApiV1PrefecturesIdHandler) GetApiV1PrefecturesId(ctx echo.Context, arg1 int) error {
+	prefectureID := arg1
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.GetDateSpotsInput{
+		PrefectureID: &prefectureID,
+	})
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotsResponse(output.DateSpots))
 }

--- a/internal/interface/handler/get_api_v1_prefectures_id_test.go
+++ b/internal/interface/handler/get_api_v1_prefectures_id_test.go
@@ -1,0 +1,70 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1PrefecturesIdHandler(t *testing.T) {
+	t.Run("success_returns_200_with_date_spots_array", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		prefectureID := 1
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{PrefectureID: &prefectureID}).
+			Return(&usecase.GetDateSpotsOutput{DateSpots: []*model.DateSpot{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/prefectures/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1PrefecturesIdHandler{InputPort: mockPort}
+		err := h.GetApiV1PrefecturesId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		prefectureID := 1
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{PrefectureID: &prefectureID}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/prefectures/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1PrefecturesIdHandler{InputPort: mockPort}
+		err := h.GetApiV1PrefecturesId(ctx, 1)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_top.go
+++ b/internal/interface/handler/get_api_v1_top.go
@@ -2,13 +2,26 @@ package handler
 
 import (
 	"net/http"
+
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
 
-type GetApiV1TopHandler struct {}
+type GetApiV1TopHandler struct {
+	InputPort usecase.GetDateSpotsInputPort
+}
 
 func (h *GetApiV1TopHandler) GetApiV1Top(ctx echo.Context) error {
-	// TODO: Implement your logic here
-	// Example: return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.GetDateSpotsInput{})
+	if err != nil {
+		return err
+	}
+	return ctx.JSON(http.StatusOK, map[string]interface{}{
+		"address_and_date_spots": openapi.NewDateSpotsResponse(output.DateSpots),
+		"areas":                  []interface{}{},
+		"genres":                 []interface{}{},
+		"main_genres":            []interface{}{},
+		"main_prefecture":        []interface{}{},
+	})
 }

--- a/internal/interface/handler/get_api_v1_top_test.go
+++ b/internal/interface/handler/get_api_v1_top_test.go
@@ -1,0 +1,72 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1TopHandler(t *testing.T) {
+	t.Run("success_returns_200_with_required_fields", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{}).
+			Return(&usecase.GetDateSpotsOutput{DateSpots: []*model.DateSpot{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/top", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1TopHandler{InputPort: mockPort}
+		err := h.GetApiV1Top(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Contains(t, resp, "address_and_date_spots")
+		assert.Contains(t, resp, "areas")
+		assert.Contains(t, resp, "genres")
+		assert.Contains(t, resp, "main_genres")
+		assert.Contains(t, resp, "main_prefecture")
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetDateSpotsInput{}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/top", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1TopHandler{InputPort: mockPort}
+		err := h.GetApiV1Top(ctx)
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -32,10 +32,16 @@ func NewHandler(container *di.Container) *Handler {
 		GetApiV1DateSpotsHandler: GetApiV1DateSpotsHandler{
 			InputPort: di.MustInvoke[usecase.GetDateSpotsInputPort](container),
 		},
-		GetApiV1DateSpotsIdHandler:   GetApiV1DateSpotsIdHandler{},
-		GetApiV1GenresIdHandler:      GetApiV1GenresIdHandler{},
-		GetApiV1PrefecturesIdHandler: GetApiV1PrefecturesIdHandler{},
-		GetApiV1TopHandler:           GetApiV1TopHandler{},
+		GetApiV1DateSpotsIdHandler: GetApiV1DateSpotsIdHandler{},
+		GetApiV1GenresIdHandler: GetApiV1GenresIdHandler{
+			InputPort: di.MustInvoke[usecase.GetDateSpotsInputPort](container),
+		},
+		GetApiV1PrefecturesIdHandler: GetApiV1PrefecturesIdHandler{
+			InputPort: di.MustInvoke[usecase.GetDateSpotsInputPort](container),
+		},
+		GetApiV1TopHandler: GetApiV1TopHandler{
+			InputPort: di.MustInvoke[usecase.GetDateSpotsInputPort](container),
+		},
 		GetApiV1UsersHandler: GetApiV1UsersHandler{
 			InputPort: di.MustInvoke[usecase.GetUsersInputPort](container),
 		},

--- a/internal/interface/handler/handler.go
+++ b/internal/interface/handler/handler.go
@@ -7,7 +7,9 @@ import (
 
 func NewHandler(container *di.Container) *Handler {
 	return &Handler{
-		DeleteApiV1CoursesIdHandler: DeleteApiV1CoursesIdHandler{},
+		DeleteApiV1CoursesIdHandler: DeleteApiV1CoursesIdHandler{
+			InputPort: di.MustInvoke[usecase.DeleteCourseInputPort](container),
+		},
 		DeleteApiV1DateSpotReviewsIdHandler: DeleteApiV1DateSpotReviewsIdHandler{
 			InputPort: di.MustInvoke[usecase.DeleteDateSpotReviewInputPort](container),
 		},

--- a/internal/usecase/delete_course.go
+++ b/internal/usecase/delete_course.go
@@ -1,0 +1,33 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+)
+
+type DeleteCourseInputPort interface {
+	Execute(context.Context, DeleteCourseInput) (*DeleteCourseOutput, error)
+}
+
+type DeleteCourseInput struct {
+	CourseID uint
+}
+
+type DeleteCourseOutput struct{}
+
+type DeleteCourseInteractor struct {
+	CourseRepository repository.CourseRepository
+}
+
+func NewDeleteCourseUsecase(courseRepository repository.CourseRepository) DeleteCourseInputPort {
+	return &DeleteCourseInteractor{CourseRepository: courseRepository}
+}
+
+func (i *DeleteCourseInteractor) Execute(ctx context.Context, input DeleteCourseInput) (*DeleteCourseOutput, error) {
+	if err := i.CourseRepository.DeleteByID(ctx, input.CourseID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+	return &DeleteCourseOutput{}, nil
+}

--- a/internal/usecase/delete_course_test.go
+++ b/internal/usecase/delete_course_test.go
@@ -1,0 +1,50 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteCourseUsecase(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockCourseRepo.EXPECT().
+			DeleteByID(gomock.Any(), uint(1)).
+			Return(nil)
+
+		uc := usecase.NewDeleteCourseUsecase(mockCourseRepo)
+		_, err := uc.Execute(context.Background(), usecase.DeleteCourseInput{CourseID: 1})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("error_repository_delete_failed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockCourseRepo := repomock.NewMockCourseRepository(ctrl)
+		mockCourseRepo.EXPECT().
+			DeleteByID(gomock.Any(), uint(1)).
+			Return(errors.New("db error"))
+
+		uc := usecase.NewDeleteCourseUsecase(mockCourseRepo)
+		_, err := uc.Execute(context.Background(), usecase.DeleteCourseInput{CourseID: 1})
+
+		require.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/usecase/mock/delete_course.go
+++ b/internal/usecase/mock/delete_course.go
@@ -1,0 +1,41 @@
+package usecasemock
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"go.uber.org/mock/gomock"
+)
+
+type MockDeleteCourseInputPort struct {
+	ctrl     *gomock.Controller
+	recorder *MockDeleteCourseInputPortMockRecorder
+}
+
+type MockDeleteCourseInputPortMockRecorder struct {
+	mock *MockDeleteCourseInputPort
+}
+
+func NewMockDeleteCourseInputPort(ctrl *gomock.Controller) *MockDeleteCourseInputPort {
+	mock := &MockDeleteCourseInputPort{ctrl: ctrl}
+	mock.recorder = &MockDeleteCourseInputPortMockRecorder{mock}
+	return mock
+}
+
+func (m *MockDeleteCourseInputPort) EXPECT() *MockDeleteCourseInputPortMockRecorder {
+	return m.recorder
+}
+
+func (m *MockDeleteCourseInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteCourseInput) (*usecase.DeleteCourseOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
+	ret0, _ := ret[0].(*usecase.DeleteCourseOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (mr *MockDeleteCourseInputPortMockRecorder) Execute(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockDeleteCourseInputPort)(nil).Execute), arg0, arg1)
+}


### PR DESCRIPTION
Closes #61
Closes #62
Closes #63

## 変更内容

Rails の `HomesController#top`、`PrefecturesController#show`、`GenresController#show` に相当する 3 エンドポイントを Go に実装。

### 実装方針
- 3 ハンドラーすべてで既存の `GetDateSpotsUsecase` を再利用（新規 usecase 不要）
- `GetDateSpotsInput` のフィールドを用途に応じて使い分け
  - `GET /api/v1/top` → `GetDateSpotsInput{}` (全件取得)
  - `GET /api/v1/prefectures/:id` → `GetDateSpotsInput{PrefectureID: &id}`
  - `GET /api/v1/genres/:id` → `GetDateSpotsInput{GenreID: &id}`

### レスポンス形式
- `/top` → `address_and_date_spots`, `areas`, `genres`, `main_genres`, `main_prefecture` を含む JSON
- `/prefectures/:id` → `[]AddressAndDateSpotsDataResponse` (配列直接返却)
- `/genres/:id` → `{"address_and_date_spots": [...]}`

## 変更ファイル
- `internal/interface/handler/get_api_v1_top.go`
- `internal/interface/handler/get_api_v1_prefectures_id.go`
- `internal/interface/handler/get_api_v1_genres_id.go`
- `internal/interface/handler/handler.go` — DI 配線追加
- テストファイル 3 件（Red → Green）
