### PR TITLE
feat: courses の prefecture_id フィルタを実装

### DIFF
--- a/internal/domain/repository/course_repository.go
+++ b/internal/domain/repository/course_repository.go
@@ -6,10 +6,14 @@ import (
 	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 )
 
+type CourseSearchParams struct {
+	PrefectureID *int
+}
+
 type CourseRepository interface {
 	Create(ctx context.Context, course *model.Course) error
 	FindByUserID(ctx context.Context, userID uint) ([]*model.Course, error)
-	FindAll(ctx context.Context) ([]*model.Course, error)
+	Search(ctx context.Context, params CourseSearchParams) ([]*model.Course, error)
 	FindByID(ctx context.Context, id uint) (*model.Course, error)
 	DeleteByID(ctx context.Context, id uint) error
 }

--- a/internal/domain/repository/mock/course_repository.go
+++ b/internal/domain/repository/mock/course_repository.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repository "github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -69,19 +70,19 @@ func (mr *MockCourseRepositoryMockRecorder) DeleteByID(ctx, id any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockCourseRepository)(nil).DeleteByID), ctx, id)
 }
 
-// FindAll mocks base method.
-func (m *MockCourseRepository) FindAll(ctx context.Context) ([]*model.Course, error) {
+// Search mocks base method.
+func (m *MockCourseRepository) Search(ctx context.Context, params repository.CourseSearchParams) ([]*model.Course, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", ctx)
+	ret := m.ctrl.Call(m, "Search", ctx, params)
 	ret0, _ := ret[0].([]*model.Course)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindAll indicates an expected call of FindAll.
-func (mr *MockCourseRepositoryMockRecorder) FindAll(ctx any) *gomock.Call {
+// Search indicates an expected call of Search.
+func (mr *MockCourseRepositoryMockRecorder) Search(ctx, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockCourseRepository)(nil).FindAll), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockCourseRepository)(nil).Search), ctx, params)
 }
 
 // FindByID mocks base method.

--- a/internal/infrastructure/persistence/course_repository.go
+++ b/internal/infrastructure/persistence/course_repository.go
@@ -6,6 +6,7 @@ import (
 
 	model "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"gorm.io/gorm"
 )
 
@@ -40,15 +41,23 @@ func (r *courseRepository) FindByUserID(ctx context.Context, userID uint) ([]*mo
 	return courses, nil
 }
 
-// FindAll はすべてのコース一覧を返します。
-func (r *courseRepository) FindAll(ctx context.Context) ([]*model.Course, error) {
+// Search はフィルタ条件に基づいてコース一覧を返します。
+func (r *courseRepository) Search(ctx context.Context, params repository.CourseSearchParams) ([]*model.Course, error) {
 	var courses []*model.Course
-	if err := r.db.WithContext(ctx).
+	db := r.db.WithContext(ctx).
 		Preload("User").
-		Preload("DuringSpots.DateSpot").
-		Find(&courses).Error; err != nil {
-		slog.ErrorContext(ctx, "courseRepository.FindAll failed", "err", err)
-		return nil, err
+		Preload("DuringSpots.DateSpot")
+
+	if params.PrefectureID != nil {
+		db = db.Joins("JOIN during_spots ON during_spots.course_id = courses.id").
+			Joins("JOIN date_spots ON date_spots.id = during_spots.date_spot_id").
+			Where("date_spots.prefecture_id = ?", *params.PrefectureID).
+			Distinct("courses.*")
+	}
+
+	if err := db.Find(&courses).Error; err != nil {
+		slog.ErrorContext(ctx, "courseRepository.Search failed", "err", err)
+		return nil, apperror.InternalServerError(err)
 	}
 	return courses, nil
 }

--- a/internal/interface/handler/get_api_v1_courses.go
+++ b/internal/interface/handler/get_api_v1_courses.go
@@ -14,8 +14,10 @@ type GetApiV1CoursesHandler struct {
 }
 
 func (h *GetApiV1CoursesHandler) GetApiV1Courses(ctx echo.Context, params openapi.GetApiV1CoursesParams) error {
-	// params currently unused by usecase; map if needed in future
-	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.GetCoursesInput{})
+	input := usecase.GetCoursesInput{
+		PrefectureID: params.PrefectureId,
+	}
+	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
 	if err != nil {
 		return err
 	}

--- a/internal/interface/handler/get_api_v1_courses_test.go
+++ b/internal/interface/handler/get_api_v1_courses_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
 	"github.com/labstack/echo/v4"
@@ -39,7 +41,7 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 
 		h := handler.GetApiV1CoursesHandler{InputPort: mockPort}
-		err := h.GetApiV1Courses(ctx)
+		err := h.GetApiV1Courses(ctx, openapi.GetApiV1CoursesParams{})
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -49,6 +51,38 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		assert.Contains(t, resp, "courses")
 		coursesList := resp["courses"].([]interface{})
 		assert.Equal(t, 2, len(coursesList))
+	})
+
+	t.Run("success_with_prefecture_id_filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		now := time.Now()
+		prefectureID := 13
+		courses := []*model.Course{
+			{ID: 1, UserID: 1, TravelMode: "car", Authority: "public", CreatedAt: now, UpdatedAt: now},
+		}
+
+		mockPort := usecasemock.NewMockGetCoursesInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetCoursesInput{PrefectureID: &prefectureID}).
+			Return(&usecase.GetCoursesOutput{Courses: courses}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/courses?prefecture_id=13", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1CoursesHandler{InputPort: mockPort}
+		err := h.GetApiV1Courses(ctx, openapi.GetApiV1CoursesParams{PrefectureId: &prefectureID})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		coursesList := resp["courses"].([]interface{})
+		assert.Equal(t, 1, len(coursesList))
 	})
 
 	t.Run("success_returns_empty_list", func(t *testing.T) {
@@ -66,7 +100,7 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		ctx := e.NewContext(req, rec)
 
 		h := handler.GetApiV1CoursesHandler{InputPort: mockPort}
-		err := h.GetApiV1Courses(ctx)
+		err := h.GetApiV1Courses(ctx, openapi.GetApiV1CoursesParams{})
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
@@ -75,5 +109,25 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 		coursesList := resp["courses"].([]interface{})
 		assert.Equal(t, 0, len(coursesList))
+	})
+
+	t.Run("error_usecase_failure_returns_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetCoursesInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetCoursesInput{}).
+			Return(nil, apperror.InternalServerError(nil))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/courses", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1CoursesHandler{InputPort: mockPort}
+		err := h.GetApiV1Courses(ctx, openapi.GetApiV1CoursesParams{})
+
+		assert.Error(t, err)
 	})
 }

--- a/internal/usecase/get_courses.go
+++ b/internal/usecase/get_courses.go
@@ -11,7 +11,9 @@ type GetCoursesInputPort interface {
 	Execute(context.Context, GetCoursesInput) (*GetCoursesOutput, error)
 }
 
-type GetCoursesInput struct{}
+type GetCoursesInput struct {
+	PrefectureID *int
+}
 
 type GetCoursesOutput struct {
 	Courses []*model.Course
@@ -30,7 +32,9 @@ func NewGetCoursesUsecase(
 }
 
 func (i *GetCoursesInteractor) Execute(ctx context.Context, input GetCoursesInput) (*GetCoursesOutput, error) {
-	courses, err := i.CourseRepository.FindAll(ctx)
+	courses, err := i.CourseRepository.Search(ctx, repository.CourseSearchParams{
+		PrefectureID: input.PrefectureID,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/get_courses_test.go
+++ b/internal/usecase/get_courses_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	repositorymock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestGetCoursesInteractor_Execute(t *testing.T) {
 			{ID: 2, UserID: 2, TravelMode: "walk", Authority: "public"},
 		}
 		mockRepo.EXPECT().
-			FindAll(gomock.Any()).
+			Search(gomock.Any(), repository.CourseSearchParams{}).
 			Return(courses, nil)
 
 		interactor := usecase.NewGetCoursesUsecase(mockRepo)
@@ -36,13 +37,33 @@ func TestGetCoursesInteractor_Execute(t *testing.T) {
 		assert.Equal(t, uint(2), output.Courses[1].ID)
 	})
 
+	t.Run("success_with_prefecture_id_filter", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockRepo := repositorymock.NewMockCourseRepository(ctrl)
+		prefectureID := 13
+		courses := []*model.Course{
+			{ID: 1, UserID: 1, TravelMode: "car", Authority: "public"},
+		}
+		mockRepo.EXPECT().
+			Search(gomock.Any(), repository.CourseSearchParams{PrefectureID: &prefectureID}).
+			Return(courses, nil)
+
+		interactor := usecase.NewGetCoursesUsecase(mockRepo)
+		output, err := interactor.Execute(context.Background(), usecase.GetCoursesInput{PrefectureID: &prefectureID})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(output.Courses))
+	})
+
 	t.Run("success_returns_empty_list", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockRepo := repositorymock.NewMockCourseRepository(ctrl)
 		mockRepo.EXPECT().
-			FindAll(gomock.Any()).
+			Search(gomock.Any(), repository.CourseSearchParams{}).
 			Return([]*model.Course{}, nil)
 
 		interactor := usecase.NewGetCoursesUsecase(mockRepo)
@@ -58,7 +79,7 @@ func TestGetCoursesInteractor_Execute(t *testing.T) {
 
 		mockRepo := repositorymock.NewMockCourseRepository(ctrl)
 		mockRepo.EXPECT().
-			FindAll(gomock.Any()).
+			Search(gomock.Any(), repository.CourseSearchParams{}).
 			Return(nil, apperror.InternalServerError(nil))
 
 		interactor := usecase.NewGetCoursesUsecase(mockRepo)


### PR DESCRIPTION
## 概要

Rails バックエンドでは `GET /api/v1/courses` に `prefecture_id` クエリパラメータを渡すことでコースを都道府県で絞り込めるが、Go バックエンドではこのパラメータが無視されていた。本 PR でその差分を解消する。

## 変更内容

- `CourseRepository` インターフェースに `CourseSearchParams` 型を追加し、`FindAll` を `Search(ctx, params)` に変更
- `GetCoursesInput` に `PrefectureID *int` フィールドを追加
- handler が `params.PrefectureId` を `GetCoursesInput` に渡すよう修正
- persistence 層で `prefecture_id` 指定時に `during_spots → date_spots` を JOIN して絞り込み
- repository mock、usecase テスト、handler テストをすべて更新

## テスト

- `TestGetCoursesInteractor_Execute/success_with_prefecture_id_filter` — prefecture_id フィルタありの正常系
- `TestGetApiV1CoursesHandler/success_with_prefecture_id_filter` — handler 経由での prefecture_id テスト