### PR TITLE
feat: JWT トークン認証の実装（closes #81）

### DIFF
--- a/api/OpenAPI.yaml
+++ b/api/OpenAPI.yaml
@@ -61,4 +61,10 @@ paths:
     $ref: "./paths/courses.yaml"
   /api/v1/courses/{id}:
     $ref: "./paths/courses_id.yaml"
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
 

--- a/api/components/schemas/response/session.yaml
+++ b/api/components/schemas/response/session.yaml
@@ -4,6 +4,9 @@ components:
       type: object
       required:
         - login_status
+        - token
       properties:
         login_status:
           type: boolean
+        token:
+          type: string

--- a/api/paths/courses.yaml
+++ b/api/paths/courses.yaml
@@ -21,6 +21,8 @@ get:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 post:
   tags: ["course"]
+  security:
+    - bearerAuth: []
   requestBody:
     required: true
     content:

--- a/api/paths/courses_id.yaml
+++ b/api/paths/courses_id.yaml
@@ -19,6 +19,8 @@ get:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 delete:
   tags: ["course"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   responses:

--- a/api/paths/date_spot_reviews.yaml
+++ b/api/paths/date_spot_reviews.yaml
@@ -1,5 +1,7 @@
 post:
   tags: ["date_spot_review"]
+  security:
+    - bearerAuth: []
   requestBody:
     required: true
     content:

--- a/api/paths/date_spot_reviews_id.yaml
+++ b/api/paths/date_spot_reviews_id.yaml
@@ -1,5 +1,7 @@
 put:
   tags: ["date_spot_review"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   requestBody:
@@ -23,6 +25,8 @@ put:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 delete:
   tags: ["date_spot_review"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   responses:

--- a/api/paths/date_spots.yaml
+++ b/api/paths/date_spots.yaml
@@ -38,6 +38,8 @@ get:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 post:
   tags: ["date_spot"]
+  security:
+    - bearerAuth: []
   requestBody:
     required: true
     content:

--- a/api/paths/date_spots_id.yaml
+++ b/api/paths/date_spots_id.yaml
@@ -17,6 +17,8 @@ get:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 put:
   tags: ["date_spot"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   requestBody:
@@ -40,6 +42,8 @@ put:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 delete:
   tags: ["date_spot"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   responses:

--- a/api/paths/relationships.yaml
+++ b/api/paths/relationships.yaml
@@ -1,5 +1,7 @@
 post:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   requestBody:
     required: true
     content:

--- a/api/paths/relationships_current_user_id_other_user_id.yaml
+++ b/api/paths/relationships_current_user_id_other_user_id.yaml
@@ -1,5 +1,7 @@
 delete:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/CurrentUserIdParam"
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/OtherUserIdParam"

--- a/api/paths/users_id.yaml
+++ b/api/paths/users_id.yaml
@@ -17,6 +17,8 @@ get:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 put:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   requestBody:
@@ -40,6 +42,8 @@ put:
             $ref: "../components/schemas/response/error.yaml#/components/schemas/ErrorResponse"
 delete:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/IdParam"
   responses:

--- a/api/paths/users_user_id_followers.yaml
+++ b/api/paths/users_user_id_followers.yaml
@@ -1,5 +1,7 @@
 get:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/UserIdParam"
   responses:

--- a/api/paths/users_user_id_followings.yaml
+++ b/api/paths/users_user_id_followings.yaml
@@ -1,5 +1,7 @@
 get:
   tags: ["user"]
+  security:
+    - bearerAuth: []
   parameters:
     - $ref: "../components/schemas/parameter.yaml#/components/parameters/UserIdParam"
   responses:

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -145,6 +145,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
     get:
@@ -195,6 +197,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
   /api/v1/users/{user_id}/followings:
@@ -218,6 +222,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
   /api/v1/users/{user_id}/followers:
@@ -241,6 +247,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
   /api/v1/relationships:
@@ -264,6 +272,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
   /api/v1/relationships/{current_user_id}/{other_user_id}:
@@ -292,6 +302,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - user
   /api/v1/date_spots:
@@ -354,6 +366,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot
   /api/v1/date_spots/{id}:
@@ -373,6 +387,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot
     get:
@@ -423,6 +439,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot
   /api/v1/date_spot_reviews:
@@ -446,6 +464,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot_review
   /api/v1/date_spot_reviews/{id}:
@@ -463,6 +483,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/DateSpotReviewResponseData"
           description: Successful response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot_review
     put:
@@ -491,6 +513,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
           description: Error response
+      security:
+      - bearerAuth: []
       tags:
       - date_spot_review
   /api/v1/prefectures/{id}:
@@ -574,6 +598,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/CourseFormResponseData"
           description: Successful response
+      security:
+      - bearerAuth: []
       tags:
       - course
   /api/v1/courses/{id}:
@@ -587,6 +613,8 @@ paths:
       responses:
         "204":
           description: Successful response
+      security:
+      - bearerAuth: []
       tags:
       - course
     get:
@@ -779,11 +807,15 @@ components:
     LoginResponseData:
       example:
         login_status: true
+        token: token
       properties:
         login_status:
           type: boolean
+        token:
+          type: string
       required:
       - login_status
+      - token
       type: object
     UserResponseData:
       example:
@@ -2369,3 +2401,8 @@ components:
       - user_image
       - user_name
       type: object
+  securitySchemes:
+    bearerAuth:
+      bearerFormat: JWT
+      scheme: bearer
+      type: http

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,10 +16,15 @@ var (
 type Config struct {
 	DB         DBConfig
 	GoogleMaps GoogleMapsConfig
+	JWT        JWTConfig
 }
 
 type GoogleMapsConfig struct {
 	APIKey string `envconfig:"GOOGLE_MAPS_API_KEY" required:"true"`
+}
+
+type JWTConfig struct {
+	SecretKey string `envconfig:"JWT_SECRET_KEY" required:"true"`
 }
 
 type DBConfig struct {
@@ -45,6 +50,9 @@ func Get() *Config {
 		}
 		if e := envconfig.Process("", &cfg.GoogleMaps); e != nil {
 			slog.Error("failed to process environment google maps", "err", e)
+		}
+		if e := envconfig.Process("", &cfg.JWT); e != nil {
+			slog.Error("failed to process environment jwt", "err", e)
 		}
 	})
 

--- a/internal/di/infrastructure.go
+++ b/internal/di/infrastructure.go
@@ -32,8 +32,14 @@ func ProvideServices(ct *Container) {
 	ct.MustProvide(service.NewUserService)
 }
 
+// ProvideJWTSecretKey は設定から JWT シークレットキーを提供します。
+func ProvideJWTSecretKey(cfg *config.Config) usecase.JWTSecretKey {
+	return usecase.JWTSecretKey(cfg.JWT.SecretKey)
+}
+
 // ProvideUsecases は全ユースケースのコンストラクタを Container に登録します。
 func ProvideUsecases(ct *Container) {
+	ct.MustProvide(ProvideJWTSecretKey)
 	ct.MustProvide(usecase.NewGetDateSpotsUsecase)
 	ct.MustProvide(usecase.NewCreateDateSpotUsecase)
 	ct.MustProvide(usecase.NewUpdateDateSpotUsecase)

--- a/internal/domain/repository/mock/course_repository.go
+++ b/internal/domain/repository/mock/course_repository.go
@@ -70,21 +70,6 @@ func (mr *MockCourseRepositoryMockRecorder) DeleteByID(ctx, id any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockCourseRepository)(nil).DeleteByID), ctx, id)
 }
 
-// Search mocks base method.
-func (m *MockCourseRepository) Search(ctx context.Context, params repository.CourseSearchParams) ([]*model.Course, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, params)
-	ret0, _ := ret[0].([]*model.Course)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Search indicates an expected call of Search.
-func (mr *MockCourseRepositoryMockRecorder) Search(ctx, params any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockCourseRepository)(nil).Search), ctx, params)
-}
-
 // FindByID mocks base method.
 func (m *MockCourseRepository) FindByID(ctx context.Context, id uint) (*model.Course, error) {
 	m.ctrl.T.Helper()
@@ -113,4 +98,19 @@ func (m *MockCourseRepository) FindByUserID(ctx context.Context, userID uint) ([
 func (mr *MockCourseRepositoryMockRecorder) FindByUserID(ctx, userID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByUserID", reflect.TypeOf((*MockCourseRepository)(nil).FindByUserID), ctx, userID)
+}
+
+// Search mocks base method.
+func (m *MockCourseRepository) Search(ctx context.Context, params repository.CourseSearchParams) ([]*model.Course, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Search", ctx, params)
+	ret0, _ := ret[0].([]*model.Course)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Search indicates an expected call of Search.
+func (mr *MockCourseRepositoryMockRecorder) Search(ctx, params any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockCourseRepository)(nil).Search), ctx, params)
 }

--- a/internal/interface/handler/post_api_v1_login.go
+++ b/internal/interface/handler/post_api_v1_login.go
@@ -22,7 +22,7 @@ func (h *PostApiV1LoginHandler) PostApiV1Login(ctx echo.Context) error {
 		return err
 	}
 
-	resp, err := openapi.NewLoginResponse(output.User)
+	resp, err := openapi.NewLoginResponse(output.User, output.Token)
 	if err != nil {
 		return err
 	}

--- a/internal/interface/middleware/auth.go
+++ b/internal/interface/middleware/auth.go
@@ -1,0 +1,81 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+	jwtpkg "github.com/daisuke-harada/date-courses-go/internal/pkg/jwt"
+	"github.com/labstack/echo/v4"
+)
+
+// publicPaths は認証不要なパスのセットです。
+// POST /api/v1/login, POST /api/v1/signup はメソッドも一致させて除外します。
+// GET 系の公開エンドポイントはメソッドがGETの場合のみ除外します。
+var publicGETPrefixes = []string{
+	"/",
+	"/api/v1/top",
+	"/api/v1/date_spots",
+	"/api/v1/date_spot_reviews",
+	"/api/v1/prefectures",
+	"/api/v1/genres",
+	"/api/v1/users",
+	"/api/v1/courses",
+}
+
+var publicPOSTPaths = []string{
+	"/api/v1/login",
+	"/api/v1/signup",
+}
+
+func isPublic(method, path string) bool {
+	if method == http.MethodPost {
+		for _, p := range publicPOSTPaths {
+			if path == p {
+				return true
+			}
+		}
+		return false
+	}
+	if method == http.MethodGet {
+		for _, prefix := range publicGETPrefixes {
+			if path == prefix || strings.HasPrefix(path, prefix+"/") || strings.HasPrefix(path, prefix+"?") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// JWTAuthMiddleware は JWT Bearer トークンを検証し、currentUser をコンテキストにセットします。
+func JWTAuthMiddleware(secretKey string, userRepo repository.UserRepository) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(ctx echo.Context) error {
+			req := ctx.Request()
+
+			if isPublic(req.Method, req.URL.Path) {
+				return next(ctx)
+			}
+
+			authHeader := req.Header.Get("Authorization")
+			if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+				return apperror.Unauthorized("認証が必要です。")
+			}
+
+			tokenStr := strings.TrimPrefix(authHeader, "Bearer ")
+			userID, err := jwtpkg.Decode(tokenStr, secretKey)
+			if err != nil {
+				return err
+			}
+
+			user, err := userRepo.FindByID(req.Context(), userID)
+			if err != nil {
+				return apperror.Unauthorized("認証が必要です。")
+			}
+
+			ctx.Set("currentUser", user)
+			return next(ctx)
+		}
+	}
+}

--- a/internal/interface/middleware/auth_test.go
+++ b/internal/interface/middleware/auth_test.go
@@ -1,0 +1,150 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repositorymock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/middleware"
+	jwtpkg "github.com/daisuke-harada/date-courses-go/internal/pkg/jwt"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+const testSecret = "test-secret"
+
+func dummyHandler(ctx echo.Context) error {
+	return ctx.String(http.StatusOK, "ok")
+}
+
+func newEchoWithAuth(t *testing.T, userRepo *repositorymock.MockUserRepository) *echo.Echo {
+	t.Helper()
+	e := echo.New()
+	e.HTTPErrorHandler = middleware.CustomHTTPErrorHandler
+	e.Use(middleware.JWTAuthMiddleware(testSecret, userRepo))
+	e.GET("/api/v1/protected", dummyHandler)
+	e.POST("/api/v1/login", dummyHandler)
+	e.POST("/api/v1/signup", dummyHandler)
+	e.GET("/", dummyHandler)
+	e.GET("/api/v1/top", dummyHandler)
+	e.GET("/api/v1/date_spots", dummyHandler)
+	return e
+}
+
+func TestJWTAuthMiddleware(t *testing.T) {
+	t.Run("success_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_no_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("error_invalid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+		req.Header.Set("Authorization", "Bearer invalid.token")
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("error_expired_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		token, err := jwtpkg.EncodeWithExpiry(1, testSecret, time.Now().Add(-1*time.Hour))
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("skip_login_endpoint", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/login", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("skip_signup_endpoint", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/signup", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("skip_public_get_endpoints", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+
+		for _, path := range []string{"/", "/api/v1/top", "/api/v1/date_spots"} {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusOK, rec.Code, "path: %s should be public", path)
+		}
+	})
+}

--- a/internal/interface/openapi/api_server.gen.go
+++ b/internal/interface/openapi/api_server.gen.go
@@ -129,6 +129,8 @@ func (w *ServerInterfaceWrapper) GetApiV1Courses(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) PostApiV1Courses(ctx echo.Context) error {
 	var err error
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PostApiV1Courses(ctx)
 	return err
@@ -144,6 +146,8 @@ func (w *ServerInterfaceWrapper) DeleteApiV1CoursesId(ctx echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.DeleteApiV1CoursesId(ctx, id)
@@ -170,6 +174,8 @@ func (w *ServerInterfaceWrapper) GetApiV1CoursesId(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) PostApiV1DateSpotReviews(ctx echo.Context) error {
 	var err error
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PostApiV1DateSpotReviews(ctx)
 	return err
@@ -186,6 +192,8 @@ func (w *ServerInterfaceWrapper) DeleteApiV1DateSpotReviewsId(ctx echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.DeleteApiV1DateSpotReviewsId(ctx, id)
 	return err
@@ -201,6 +209,8 @@ func (w *ServerInterfaceWrapper) PutApiV1DateSpotReviewsId(ctx echo.Context) err
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PutApiV1DateSpotReviewsId(ctx, id)
@@ -250,6 +260,8 @@ func (w *ServerInterfaceWrapper) GetApiV1DateSpots(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) PostApiV1DateSpots(ctx echo.Context) error {
 	var err error
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PostApiV1DateSpots(ctx)
 	return err
@@ -265,6 +277,8 @@ func (w *ServerInterfaceWrapper) DeleteApiV1DateSpotsId(ctx echo.Context) error 
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.DeleteApiV1DateSpotsId(ctx, id)
@@ -297,6 +311,8 @@ func (w *ServerInterfaceWrapper) PutApiV1DateSpotsId(ctx echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PutApiV1DateSpotsId(ctx, id)
@@ -348,6 +364,8 @@ func (w *ServerInterfaceWrapper) GetApiV1PrefecturesId(ctx echo.Context) error {
 func (w *ServerInterfaceWrapper) PostApiV1Relationships(ctx echo.Context) error {
 	var err error
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PostApiV1Relationships(ctx)
 	return err
@@ -371,6 +389,8 @@ func (w *ServerInterfaceWrapper) DeleteApiV1RelationshipsCurrentUserIdOtherUserI
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter other_user_id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx, currentUserId, otherUserId)
@@ -424,6 +444,8 @@ func (w *ServerInterfaceWrapper) DeleteApiV1UsersId(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.DeleteApiV1UsersId(ctx, id)
 	return err
@@ -456,6 +478,8 @@ func (w *ServerInterfaceWrapper) PutApiV1UsersId(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
 	}
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.PutApiV1UsersId(ctx, id)
 	return err
@@ -472,6 +496,8 @@ func (w *ServerInterfaceWrapper) GetApiV1UsersUserIdFollowers(ctx echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter user_id: %s", err))
 	}
 
+	ctx.Set(BearerAuthScopes, []string{})
+
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetApiV1UsersUserIdFollowers(ctx, userId)
 	return err
@@ -487,6 +513,8 @@ func (w *ServerInterfaceWrapper) GetApiV1UsersUserIdFollowings(ctx echo.Context)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter user_id: %s", err))
 	}
+
+	ctx.Set(BearerAuthScopes, []string{})
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.GetApiV1UsersUserIdFollowings(ctx, userId)

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -9,6 +9,10 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+const (
+	BearerAuthScopes = "bearerAuth.Scopes"
+)
+
 // Defines values for CourseFormRequestDataAuthority.
 const (
 	CourseFormRequestDataAuthorityEmpty CourseFormRequestDataAuthority = "公開"
@@ -166,7 +170,8 @@ type ImageData1 struct {
 
 // LoginResponseData defines model for LoginResponseData.
 type LoginResponseData struct {
-	LoginStatus bool `json:"login_status"`
+	LoginStatus bool   `json:"login_status"`
+	Token       string `json:"token"`
 }
 
 // RelationShipResponsData defines model for RelationShipResponsData.

--- a/internal/interface/openapi/login.go
+++ b/internal/interface/openapi/login.go
@@ -2,14 +2,12 @@ package openapi
 
 import "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 
-// LoginResponseBody は POST /api/v1/login のレスポンス型です。
-// Rails の SessionsSerializer / UserSerializer に対応します。
 type LoginResponseBody struct {
 	User        LoginUserResponseData `json:"user"`
 	LoginStatus bool                  `json:"login_status"`
+	Token       string                `json:"token"`
 }
 
-// LoginUserResponseData はログインレスポンスに含まれるユーザーデータです。
 type LoginUserResponseData struct {
 	ID     uint    `json:"id"`
 	Name   string  `json:"name"`
@@ -19,8 +17,7 @@ type LoginUserResponseData struct {
 	Admin  bool    `json:"admin"`
 }
 
-// NewLoginResponse は LoginOutput からレスポンス型を生成します。
-func NewLoginResponse(user *model.User) (LoginResponseBody, error) {
+func NewLoginResponse(user *model.User, token string) (LoginResponseBody, error) {
 	gender, err := NewGender(user.Gender)
 	if err != nil {
 		return LoginResponseBody{}, err
@@ -35,5 +32,6 @@ func NewLoginResponse(user *model.User) (LoginResponseBody, error) {
 			Admin:  user.Admin,
 		},
 		LoginStatus: true,
+		Token:       token,
 	}, nil
 }

--- a/internal/interface/server.go
+++ b/internal/interface/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/daisuke-harada/date-courses-go/internal/config"
 	"github.com/daisuke-harada/date-courses-go/internal/di"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/middleware"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
@@ -76,7 +77,7 @@ func Run(ctx context.Context) error {
 	})
 }
 
-func NewEcho() *echo.Echo {
+func NewEcho(cfg *config.Config, userRepo repository.UserRepository) *echo.Echo {
 	e := echo.New()
 	e.HTTPErrorHandler = middleware.CustomHTTPErrorHandler
 	e.Use(echoMiddleware.Recover())
@@ -84,5 +85,6 @@ func NewEcho() *echo.Echo {
 	e.Use(middleware.CORSMiddleware())
 	e.Use(middleware.RequestIDMiddleware)
 	e.Use(middleware.AccessLogMiddleware)
+	e.Use(middleware.JWTAuthMiddleware(cfg.JWT.SecretKey, userRepo))
 	return e
 }

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -1,0 +1,50 @@
+package jwt
+
+import (
+	"errors"
+	"time"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type claims struct {
+	UserID uint `json:"user_id"`
+	jwt.RegisteredClaims
+}
+
+func Encode(userID uint, secretKey string) (string, error) {
+	return EncodeWithExpiry(userID, secretKey, time.Now().Add(24*time.Hour))
+}
+
+func EncodeWithExpiry(userID uint, secretKey string, expiry time.Time) (string, error) {
+	c := claims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiry),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, c)
+	return token.SignedString([]byte(secretKey))
+}
+
+func Decode(tokenStr string, secretKey string) (uint, error) {
+	token, err := jwt.ParseWithClaims(tokenStr, &claims{}, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(secretKey), nil
+	})
+	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return 0, apperror.Unauthorized("トークンの有効期限が切れています。再度ログインしてください。")
+		}
+		return 0, apperror.Unauthorized("認証に失敗しました。")
+	}
+
+	c, ok := token.Claims.(*claims)
+	if !ok || !token.Valid {
+		return 0, apperror.Unauthorized("認証に失敗しました。")
+	}
+	return c.UserID, nil
+}

--- a/internal/pkg/jwt/jwt_test.go
+++ b/internal/pkg/jwt/jwt_test.go
@@ -1,0 +1,55 @@
+package jwt_test
+
+import (
+	"testing"
+	"time"
+
+	jwtpkg "github.com/daisuke-harada/date-courses-go/internal/pkg/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSecret = "test-secret-key"
+
+func TestEncode(t *testing.T) {
+	t.Run("success_returns_non_empty_token", func(t *testing.T) {
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+		assert.NotEmpty(t, token)
+	})
+}
+
+func TestDecode(t *testing.T) {
+	t.Run("success_returns_user_id", func(t *testing.T) {
+		token, err := jwtpkg.Encode(42, testSecret)
+		require.NoError(t, err)
+
+		userID, err := jwtpkg.Decode(token, testSecret)
+		require.NoError(t, err)
+		assert.Equal(t, uint(42), userID)
+	})
+
+	t.Run("error_invalid_token", func(t *testing.T) {
+		_, err := jwtpkg.Decode("invalid.token.string", testSecret)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "認証に失敗しました。")
+	})
+
+	t.Run("error_wrong_secret", func(t *testing.T) {
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		_, err = jwtpkg.Decode(token, "wrong-secret")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "認証に失敗しました。")
+	})
+
+	t.Run("error_expired_token", func(t *testing.T) {
+		token, err := jwtpkg.EncodeWithExpiry(1, testSecret, time.Now().Add(-1*time.Hour))
+		require.NoError(t, err)
+
+		_, err = jwtpkg.Decode(token, testSecret)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "トークンの有効期限が切れています。再度ログインしてください。")
+	})
+}

--- a/internal/usecase/login.go
+++ b/internal/usecase/login.go
@@ -9,21 +9,19 @@ import (
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/service"
+	jwtpkg "github.com/daisuke-harada/date-courses-go/internal/pkg/jwt"
 	"gorm.io/gorm"
 )
 
-// LoginInputPort はログインユースケースの入力ポートです。
 type LoginInputPort interface {
 	Execute(context.Context, LoginInput) (*LoginOutput, error)
 }
 
-// LoginInput はログインの入力データです。
 type LoginInput struct {
 	Name     string
 	Password string
 }
 
-// Validate はログインの入力データをバリデーションします。
 func (i *LoginInput) Validate() error {
 	var errs []string
 
@@ -41,37 +39,39 @@ func (i *LoginInput) Validate() error {
 	return nil
 }
 
-// LoginOutput はログインの出力データです。
 type LoginOutput struct {
-	User *model.User
+	User  *model.User
+	Token string
 }
+
+type JWTSecretKey string
 
 type LoginInteractor struct {
 	UserRepository repository.UserRepository
 	AuthService    service.AuthService
+	JWTSecretKey   JWTSecretKey
 }
 
 func NewLoginUsecase(
 	userRepository repository.UserRepository,
 	authService service.AuthService,
+	jwtSecretKey JWTSecretKey,
 ) LoginInputPort {
 	return &LoginInteractor{
 		UserRepository: userRepository,
 		AuthService:    authService,
+		JWTSecretKey:   jwtSecretKey,
 	}
 }
 
 func (i *LoginInteractor) Execute(ctx context.Context, input LoginInput) (*LoginOutput, error) {
-	// バリデーション
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
 
-	// name でユーザーを検索
 	user, err := i.UserRepository.FindByName(ctx, input.Name)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// Rails と同じメッセージで 401 を返す
 			return nil, apperror.Unauthorized(
 				"認証に失敗しました。",
 				"正しい名前・パスワードを入力し直すか、新規登録を行ってください。",
@@ -80,7 +80,6 @@ func (i *LoginInteractor) Execute(ctx context.Context, input LoginInput) (*Login
 		return nil, apperror.InternalServerError(err)
 	}
 
-	// bcrypt でパスワードを検証（Rails の user.authenticate(password) 相当）
 	if !i.AuthService.CheckPassword(user.PasswordDigest, input.Password) {
 		return nil, apperror.Unauthorized(
 			"認証に失敗しました。",
@@ -88,5 +87,10 @@ func (i *LoginInteractor) Execute(ctx context.Context, input LoginInput) (*Login
 		)
 	}
 
-	return &LoginOutput{User: user}, nil
+	token, err := jwtpkg.Encode(user.ID, string(i.JWTSecretKey))
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	return &LoginOutput{User: user, Token: token}, nil
 }

--- a/internal/usecase/login_test.go
+++ b/internal/usecase/login_test.go
@@ -1,0 +1,139 @@
+package usecase_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	repositorymock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	servicemock "github.com/daisuke-harada/date-courses-go/internal/domain/service/mock"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+)
+
+const testJWTSecret usecase.JWTSecretKey = "test-secret"
+
+func newLoginUser() *model.User {
+	gender := model.GenderMale
+	return &model.User{
+		ID:             1,
+		Name:           "alice",
+		Email:          "alice@example.com",
+		Gender:         gender,
+		PasswordDigest: "$2a$10$hashed",
+	}
+}
+
+func TestLoginInteractor_Execute(t *testing.T) {
+	t.Run("success_returns_user_and_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		user := newLoginUser()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		userRepo.EXPECT().FindByName(ctx, "alice").Return(user, nil)
+		authService.EXPECT().CheckPassword(user.PasswordDigest, "password").Return(true)
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(ctx, usecase.LoginInput{Name: "alice", Password: "password"})
+
+		require.NoError(t, err)
+		require.NotNil(t, output)
+		assert.Equal(t, user, output.User)
+		assert.NotEmpty(t, output.Token)
+	})
+
+	t.Run("error_empty_name", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(context.Background(), usecase.LoginInput{Name: "", Password: "password"})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Contains(t, err.Error(), "名前を入力してください")
+	})
+
+	t.Run("error_empty_password", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(context.Background(), usecase.LoginInput{Name: "alice", Password: ""})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Contains(t, err.Error(), "パスワードを入力してください")
+	})
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		userRepo.EXPECT().FindByName(ctx, "unknown").Return(nil, gorm.ErrRecordNotFound)
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(ctx, usecase.LoginInput{Name: "unknown", Password: "password"})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Contains(t, err.Error(), "認証に失敗しました。")
+	})
+
+	t.Run("error_wrong_password", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		user := newLoginUser()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		userRepo.EXPECT().FindByName(ctx, "alice").Return(user, nil)
+		authService.EXPECT().CheckPassword(user.PasswordDigest, "wrong").Return(false)
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(ctx, usecase.LoginInput{Name: "alice", Password: "wrong"})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		assert.Contains(t, err.Error(), "認証に失敗しました。")
+	})
+
+	t.Run("error_db_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		authService := servicemock.NewMockAuthService(ctrl)
+
+		userRepo.EXPECT().FindByName(ctx, "alice").Return(nil, errors.New("db error"))
+
+		interactor := usecase.NewLoginUsecase(userRepo, authService, testJWTSecret)
+		output, err := interactor.Execute(ctx, usecase.LoginInput{Name: "alice", Password: "password"})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+	})
+}


### PR DESCRIPTION
## Summary

- `internal/pkg/jwt`: `Encode` / `Decode` JWT ユーティリティを実装（`golang-jwt/jwt/v5`）
- `LoginOutput` に `Token` フィールドを追加し、ログイン成功時に JWT を発行
- `JWTAuthMiddleware` を実装し、`Authorization: Bearer <token>` を検証してコンテキストに `currentUser` をセット
- 公開エンドポイント（`POST /login`, `POST /signup`, `GET` 系）はスキップ
- `api/OpenAPI.yaml` に `bearerAuth` securitySchemes を追加し、保護対象エンドポイントに `security` を付与
- `JWT_SECRET_KEY` 環境変数を `Config` に追加

## Test plan

- [x] `internal/pkg/jwt` のテスト（Encode/Decode 正常系・異常系・有効期限切れ）
- [x] `internal/usecase/login_test.go`（Token含む正常系・各種エラー系）
- [x] `internal/interface/middleware/auth_test.go`（正常系・トークン無し・不正トークン・有効期限切れ・公開エンドポイントスキップ）
- [x] `go build ./...` エラーなし

## Notes

`TestPostApiV1DateSpotsHandler/error_missing_name` 等のハンドラーテスト失敗は、このブランチとは無関係の pre-existing issue です（main ブランチでも同様に失敗しています）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)