### PR TITLE
test: GET /users/:id/followers の認証テストを追加する

### DIFF
--- a/internal/interface/middleware/auth_test.go
+++ b/internal/interface/middleware/auth_test.go
@@ -36,6 +36,7 @@ func newEchoWithAuth(t *testing.T, userRepo *repositorymock.MockUserRepository) 
 	e.GET("/api/v1/users", dummyHandler)
 	e.GET("/api/v1/users/:id", dummyHandler)
 	e.GET("/api/v1/users/:userId/followings", dummyHandler)
+	e.GET("/api/v1/users/:userId/followers", dummyHandler)
 	return e
 }
 
@@ -178,6 +179,40 @@ func TestJWTAuthMiddleware(t *testing.T) {
 
 		e := newEchoWithAuth(t, userRepo)
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followings", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_get_followers_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_get_followers_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)


### PR DESCRIPTION
## 背景

Rails の `RelationshipsController` は全アクションに `before_action :authenticate_user!` を設定しており、`GET /api/v1/users/:id/followers` も認証が必要。`/followers` で終わるパスの保護は PR #84 の `protectedGETSuffixes` で実装済み。本 PR はその動作を明示的にテストする。

## 変更内容

- `auth_test.go`: `error_get_followers_without_token` — 認証なし → 401
- `auth_test.go`: `success_get_followers_with_valid_token` — 有効トークン → 200

## テスト計画

- [x] `error_get_followers_without_token` — 401 を返すこと
- [x] `success_get_followers_with_valid_token` — 有効トークンで 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)