### PR TITLE
test: POST・DELETE /courses の認証テストを追加する

### DIFF
--- a/internal/interface/middleware/auth_test.go
+++ b/internal/interface/middleware/auth_test.go
@@ -37,6 +37,8 @@ func newEchoWithAuth(t *testing.T, userRepo *repositorymock.MockUserRepository) 
 	e.GET("/api/v1/users/:id", dummyHandler)
 	e.GET("/api/v1/users/:userId/followings", dummyHandler)
 	e.GET("/api/v1/users/:userId/followers", dummyHandler)
+	e.POST("/api/v1/courses", dummyHandler)
+	e.DELETE("/api/v1/courses/:id", dummyHandler)
 	return e
 }
 
@@ -213,6 +215,74 @@ func TestJWTAuthMiddleware(t *testing.T) {
 
 		e := newEchoWithAuth(t, userRepo)
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestCoursesAuthMiddleware(t *testing.T) {
+	t.Run("error_post_courses_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/courses", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_post_courses_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/courses", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_delete_courses_id_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_delete_courses_id_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)


### PR DESCRIPTION
## 背景

Rails `CoursesController` は `before_action :authenticate_user!, only: %i[create destroy]` を設定。Go のミドルウェアが POST/DELETE `/api/v1/courses` を正しく保護していることを検証する。

## 変更内容

- `auth_test.go` に `TestCoursesAuthMiddleware` を追加
  - `error_post_courses_without_token` — 401
  - `success_post_courses_with_valid_token` — 200
  - `error_delete_courses_id_without_token` — 401
  - `success_delete_courses_id_with_valid_token` — 200

## テスト計画

- [x] 全4ケースが PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)