### PR TITLE
test: POST・PUT・DELETE /date_spot_reviews の認証テストを追加する

### DIFF
--- a/internal/interface/middleware/auth_test.go
+++ b/internal/interface/middleware/auth_test.go
@@ -39,6 +39,9 @@ func newEchoWithAuth(t *testing.T, userRepo *repositorymock.MockUserRepository) 
 	e.GET("/api/v1/users/:userId/followers", dummyHandler)
 	e.POST("/api/v1/courses", dummyHandler)
 	e.DELETE("/api/v1/courses/:id", dummyHandler)
+	e.POST("/api/v1/date_spot_reviews", dummyHandler)
+	e.PUT("/api/v1/date_spot_reviews/:id", dummyHandler)
+	e.DELETE("/api/v1/date_spot_reviews/:id", dummyHandler)
 	return e
 }
 
@@ -283,6 +286,107 @@ func TestCoursesAuthMiddleware(t *testing.T) {
 
 		e := newEchoWithAuth(t, userRepo)
 		req := httptest.NewRequest(http.MethodDelete, "/api/v1/courses/1", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestDateSpotReviewsAuthMiddleware(t *testing.T) {
+	t.Run("error_post_date_spot_reviews_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/date_spot_reviews", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_post_date_spot_reviews_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/date_spot_reviews", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_put_date_spot_reviews_id_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_put_date_spot_reviews_id_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_delete_date_spot_reviews_id_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/date_spot_reviews/1", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_delete_date_spot_reviews_id_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/date_spot_reviews/1", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)


### PR DESCRIPTION
## 背景

Rails `DateSpotReviewsController` は `before_action :authenticate_user!, only: %i[create update destroy]` を設定。

## 変更内容

`TestDateSpotReviewsAuthMiddleware` を追加（POST/PUT/DELETE 各2ケース 計6テスト）

## テスト計画

- [x] 全6ケースが PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)