### PR TITLE
test: POST・DELETE /relationships の認証テストを追加する

### DIFF
--- a/internal/interface/middleware/auth_test.go
+++ b/internal/interface/middleware/auth_test.go
@@ -45,6 +45,8 @@ func newEchoWithAuth(t *testing.T, userRepo *repositorymock.MockUserRepository) 
 	e.POST("/api/v1/date_spots", dummyHandler)
 	e.PUT("/api/v1/date_spots/:id", dummyHandler)
 	e.DELETE("/api/v1/date_spots/:id", dummyHandler)
+	e.POST("/api/v1/relationships", dummyHandler)
+	e.DELETE("/api/v1/relationships/:currentUserId/:otherUserId", dummyHandler)
 	return e
 }
 
@@ -491,6 +493,74 @@ func TestDateSpotsAuthMiddleware(t *testing.T) {
 
 		e := newEchoWithAuth(t, userRepo)
 		req := httptest.NewRequest(http.MethodDelete, "/api/v1/date_spots/1", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
+func TestRelationshipsAuthMiddleware(t *testing.T) {
+	t.Run("error_post_relationships_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/relationships", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_post_relationships_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/relationships", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_delete_relationships_without_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/relationships/1/2", nil)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("success_delete_relationships_with_valid_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "alice"}
+		userRepo := repositorymock.NewMockUserRepository(ctrl)
+		userRepo.EXPECT().FindByID(gomock.Any(), uint(1)).Return(user, nil)
+
+		token, err := jwtpkg.Encode(1, testSecret)
+		require.NoError(t, err)
+
+		e := newEchoWithAuth(t, userRepo)
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/relationships/1/2", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		rec := httptest.NewRecorder()
 		e.ServeHTTP(rec, req)


### PR DESCRIPTION
## 背景

Rails `RelationshipsController` は `before_action :authenticate_user!`（`only:` なし）で全アクションに認証を要求。

## 変更内容

`TestRelationshipsAuthMiddleware` を追加（POST/DELETE 各2ケース 計4テスト）

## テスト計画

- [x] 全4ケースが PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)