### PR TITLE
fix: DateSpot ハンドラーで input.Validate() を Execute 前に呼び出す

### DIFF
--- a/internal/interface/handler/delete_api_v1_users_id_test.go
+++ b/internal/interface/handler/delete_api_v1_users_id_test.go
@@ -1,0 +1,86 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestDeleteApiV1UsersIdHandler(t *testing.T) {
+	t.Run("success_returns_204", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.DeleteUserInput{ID: 1}).
+			Return(nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1UsersId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNoContent, rec.Code)
+	})
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(apperror.NotFound())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/999", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1UsersId(ctx, 999)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockDeleteUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodDelete, "/api/v1/users/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.DeleteApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.DeleteApiV1UsersId(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_date_spots_test.go
+++ b/internal/interface/handler/get_api_v1_date_spots_test.go
@@ -1,0 +1,104 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func dummyDateSpot(id uint, name string) *model.DateSpot {
+	return &model.DateSpot{
+		ID:       id,
+		Name:     name,
+		CityName: "渋谷区",
+	}
+}
+
+func TestGetApiV1DateSpotsHandler(t *testing.T) {
+	t.Run("success_returns_200_with_date_spots", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		dateSpot := dummyDateSpot(1, "東京タワー")
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetDateSpotsOutput{DateSpots: []*model.DateSpot{dateSpot}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/date_spots", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1DateSpotsHandler{InputPort: mockPort}
+		err := h.GetApiV1DateSpots(ctx, openapi.GetApiV1DateSpotsParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 1)
+	})
+
+	t.Run("success_returns_200_empty_list", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetDateSpotsOutput{DateSpots: []*model.DateSpot{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/date_spots", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1DateSpotsHandler{InputPort: mockPort}
+		err := h.GetApiV1DateSpots(ctx, openapi.GetApiV1DateSpotsParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 0)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetDateSpotsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/date_spots", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1DateSpotsHandler{InputPort: mockPort}
+		err := h.GetApiV1DateSpots(ctx, openapi.GetApiV1DateSpotsParams{})
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_users_id_test.go
+++ b/internal/interface/handler/get_api_v1_users_id_test.go
@@ -1,0 +1,93 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1UsersIdHandler(t *testing.T) {
+	t.Run("success_returns_200_with_user", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := dummyUserWithRelations(1, "ターゲットユーザー")
+		mockPort := usecasemock.NewMockGetUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetUserInput{ID: 1}).
+			Return(&usecase.GetUserOutput{UserWithRelations: user}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, float64(1), resp["id"])
+		assert.Equal(t, "ターゲットユーザー", resp["name"])
+	})
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.NotFound())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/999", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersId(ctx, 999)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersId(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_users_test.go
+++ b/internal/interface/handler/get_api_v1_users_test.go
@@ -1,0 +1,97 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1UsersHandler(t *testing.T) {
+	t.Run("success_returns_200_with_users", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := dummyUserWithRelations(1, "ユーザー1")
+		mockPort := usecasemock.NewMockGetUsersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetUsersOutput{Users: []*model.UserWithRelations{user}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersHandler{InputPort: mockPort}
+		err := h.GetApiV1Users(ctx, openapi.GetApiV1UsersParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 1)
+		assert.Equal(t, float64(1), resp[0]["id"])
+	})
+
+	t.Run("success_returns_200_empty_list", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUsersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetUsersOutput{Users: []*model.UserWithRelations{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersHandler{InputPort: mockPort}
+		err := h.GetApiV1Users(ctx, openapi.GetApiV1UsersParams{})
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 0)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUsersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersHandler{InputPort: mockPort}
+		err := h.GetApiV1Users(ctx, openapi.GetApiV1UsersParams{})
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_users_user_id_followers_test.go
+++ b/internal/interface/handler/get_api_v1_users_user_id_followers_test.go
@@ -1,0 +1,119 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1UsersUserIdFollowersHandler(t *testing.T) {
+	t.Run("success_returns_200_with_followers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		follower := dummyUserWithRelations(3, "フォロワーユーザー")
+		mockPort := usecasemock.NewMockGetUserFollowersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetUserFollowersInput{UserID: 1}).
+			Return(&usecase.GetUserFollowersOutput{Users: []*model.UserWithRelations{follower}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowersHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowers(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 1)
+		assert.Equal(t, float64(3), resp[0]["id"])
+	})
+
+	t.Run("success_returns_200_empty_list", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetUserFollowersOutput{Users: []*model.UserWithRelations{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowersHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowers(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 0)
+	})
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.NotFound())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/999/followers", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowersHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowers(ctx, 999)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowersInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followers", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowersHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowers(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/get_api_v1_users_user_id_followings_test.go
+++ b/internal/interface/handler/get_api_v1_users_user_id_followings_test.go
@@ -1,0 +1,119 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestGetApiV1UsersUserIdFollowingsHandler(t *testing.T) {
+	t.Run("success_returns_200_with_followings", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		following := dummyUserWithRelations(2, "フォロー先ユーザー")
+		mockPort := usecasemock.NewMockGetUserFollowingsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), usecase.GetUserFollowingsInput{UserID: 1}).
+			Return(&usecase.GetUserFollowingsOutput{Users: []*model.UserWithRelations{following}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followings", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowingsHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowings(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 1)
+		assert.Equal(t, float64(2), resp[0]["id"])
+	})
+
+	t.Run("success_returns_200_empty_list", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowingsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.GetUserFollowingsOutput{Users: []*model.UserWithRelations{}}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followings", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowingsHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowings(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp []interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Len(t, resp, 0)
+	})
+
+	t.Run("error_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowingsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.NotFound())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/999/followings", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowingsHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowings(ctx, 999)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockGetUserFollowingsInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/users/1/followings", nil)
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+
+		h := handler.GetApiV1UsersUserIdFollowingsHandler{InputPort: mockPort}
+		err := h.GetApiV1UsersUserIdFollowings(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/post_api_v1_date_spots.go
+++ b/internal/interface/handler/post_api_v1_date_spots.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
@@ -15,45 +16,47 @@ type PostApiV1DateSpotsHandler struct {
 }
 
 func (h *PostApiV1DateSpotsHandler) PostApiV1DateSpots(ctx echo.Context) error {
-	// フォームデータを型変換（バリデーションは usecase で実行）
 	genreIDStr := ctx.FormValue("genre_id")
 	prefectureIDStr := ctx.FormValue("prefecture_id")
 	openingTimeStr := ctx.FormValue("opening_time")
 	closingTimeStr := ctx.FormValue("closing_time")
 
-	// GenreID のパース
 	genreID := 0
 	if genreIDStr != "" {
-		if id, err := strconv.Atoi(genreIDStr); err == nil {
-			genreID = id
+		id, err := strconv.Atoi(genreIDStr)
+		if err != nil {
+			return apperror.BadRequest("genre_id は数値で指定してください")
 		}
+		genreID = id
 	}
 
-	// PrefectureID のパース
 	prefectureID := 0
 	if prefectureIDStr != "" {
-		if id, err := strconv.Atoi(prefectureIDStr); err == nil {
-			prefectureID = id
+		id, err := strconv.Atoi(prefectureIDStr)
+		if err != nil {
+			return apperror.BadRequest("prefecture_id は数値で指定してください")
 		}
+		prefectureID = id
 	}
 
-	// OpeningTime のパース
 	var openingTime *time.Time
 	if openingTimeStr != "" {
-		if parsedTime, err := time.Parse(time.RFC3339, openingTimeStr); err == nil {
-			openingTime = &parsedTime
+		parsedTime, err := time.Parse(time.RFC3339, openingTimeStr)
+		if err != nil {
+			return apperror.UnprocessableEntity("opening_time の形式が正しくありません（RFC3339 形式で指定してください）")
 		}
+		openingTime = &parsedTime
 	}
 
-	// ClosingTime のパース
 	var closingTime *time.Time
 	if closingTimeStr != "" {
-		if parsedTime, err := time.Parse(time.RFC3339, closingTimeStr); err == nil {
-			closingTime = &parsedTime
+		parsedTime, err := time.Parse(time.RFC3339, closingTimeStr)
+		if err != nil {
+			return apperror.UnprocessableEntity("closing_time の形式が正しくありません（RFC3339 形式で指定してください）")
 		}
+		closingTime = &parsedTime
 	}
 
-	// Image は任意フィールド
 	var imagePtr *string
 	if image := ctx.FormValue("image"); image != "" {
 		imagePtr = &image
@@ -67,6 +70,10 @@ func (h *PostApiV1DateSpotsHandler) PostApiV1DateSpots(ctx echo.Context) error {
 		OpeningTime:  openingTime,
 		ClosingTime:  closingTime,
 		Image:        imagePtr,
+	}
+
+	if err := input.Validate(); err != nil {
+		return err
 	}
 
 	output, err := h.InputPort.Execute(ctx.Request().Context(), input)

--- a/internal/interface/handler/post_api_v1_login_test.go
+++ b/internal/interface/handler/post_api_v1_login_test.go
@@ -1,0 +1,92 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPostApiV1LoginHandler(t *testing.T) {
+	t.Run("success_returns_200_with_token", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 1, Name: "testuser", Email: "test@example.com", Gender: model.GenderMale}
+		mockPort := usecasemock.NewMockLoginInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.LoginOutput{User: user, Token: "test-jwt-token"}, nil)
+
+		form := url.Values{}
+		form.Set("name", "testuser")
+		form.Set("password", "password123")
+		ctx, rec := setupFormRequest(http.MethodPost, "/api/v1/login", form)
+
+		h := handler.PostApiV1LoginHandler{InputPort: mockPort}
+		err := h.PostApiV1Login(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Equal(t, "test-jwt-token", resp["token"])
+	})
+
+	t.Run("error_unauthorized_invalid_credentials", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockLoginInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.Unauthorized("名前またはパスワードが正しくありません"))
+
+		form := url.Values{}
+		form.Set("name", "wronguser")
+		form.Set("password", "wrongpass")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/login", form)
+
+		h := handler.PostApiV1LoginHandler{InputPort: mockPort}
+		err := h.PostApiV1Login(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnauthorized, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockLoginInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		form := url.Values{}
+		form.Set("name", "testuser")
+		form.Set("password", "password123")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/login", form)
+
+		h := handler.PostApiV1LoginHandler{InputPort: mockPort}
+		err := h.PostApiV1Login(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/post_api_v1_signup_test.go
+++ b/internal/interface/handler/post_api_v1_signup_test.go
@@ -1,0 +1,90 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func validSignupForm() url.Values {
+	form := url.Values{}
+	form.Set("name", "新規ユーザー")
+	form.Set("email", "newuser@example.com")
+	form.Set("gender", "女性")
+	form.Set("password", "password123")
+	form.Set("password_confirmation", "password123")
+	return form
+}
+
+func TestPostApiV1SignupHandler(t *testing.T) {
+	t.Run("success_returns_201", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := &model.User{ID: 5, Name: "新規ユーザー", Email: "newuser@example.com", Gender: model.GenderFemale}
+		mockPort := usecasemock.NewMockSignupInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.SignupOutput{User: user}, nil)
+
+		ctx, rec := setupFormRequest(http.MethodPost, "/api/v1/signup", validSignupForm())
+
+		h := handler.PostApiV1SignupHandler{InputPort: mockPort}
+		err := h.PostApiV1Signup(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockSignupInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.UnprocessableEntity("名前を入力してください"))
+
+		form := validSignupForm()
+		form.Del("name")
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/signup", form)
+
+		h := handler.PostApiV1SignupHandler{InputPort: mockPort}
+		err := h.PostApiV1Signup(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockSignupInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/signup", validSignupForm())
+
+		h := handler.PostApiV1SignupHandler{InputPort: mockPort}
+		err := h.PostApiV1Signup(ctx)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}

--- a/internal/interface/handler/put_api_v1_date_spots_id.go
+++ b/internal/interface/handler/put_api_v1_date_spots_id.go
@@ -39,6 +39,10 @@ func (h *PutApiV1DateSpotsIdHandler) PutApiV1DateSpotsId(ctx echo.Context, id in
 		Image:        req.Image,
 	}
 
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
 	if err := h.InputPort.Execute(ctx.Request().Context(), input); err != nil {
 		return err
 	}

--- a/internal/interface/handler/put_api_v1_users_id_test.go
+++ b/internal/interface/handler/put_api_v1_users_id_test.go
@@ -1,0 +1,134 @@
+package handler_test
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
+	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func validUpdateUserForm() url.Values {
+	form := url.Values{}
+	form.Set("name", "テストユーザー")
+	form.Set("email", "test@example.com")
+	form.Set("gender", "男性")
+	return form
+}
+
+func TestPutApiV1UsersIdHandler(t *testing.T) {
+	t.Run("success_returns_200", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		user := dummyUserWithRelations(1, "テストユーザー")
+		mockPort := usecasemock.NewMockUpdateUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(&usecase.UpdateUserOutput{UserWithRelations: user}, nil)
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/users/1", strings.NewReader(validUpdateUserForm().Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("1")
+
+		h := handler.PutApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.PutApiV1UsersId(ctx, 1)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.UnprocessableEntity("名前を入力してください"))
+
+		form := validUpdateUserForm()
+		form.Del("name")
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/users/1", strings.NewReader(form.Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("1")
+
+		h := handler.PutApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.PutApiV1UsersId(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
+	})
+
+	t.Run("error_usecase_returns_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.NotFound())
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/users/999", strings.NewReader(validUpdateUserForm().Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("999")
+
+		h := handler.PutApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.PutApiV1UsersId(ctx, 999)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateUserInputPort(ctrl)
+		mockPort.EXPECT().
+			Execute(gomock.Any(), gomock.Any()).
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodPut, "/api/v1/users/1", strings.NewReader(validUpdateUserForm().Encode()))
+		req.Header.Set(echo.HeaderContentType, "application/x-www-form-urlencoded")
+		rec := httptest.NewRecorder()
+		ctx := e.NewContext(req, rec)
+		ctx.SetParamNames("id")
+		ctx.SetParamValues("1")
+
+		h := handler.PutApiV1UsersIdHandler{InputPort: mockPort}
+		err := h.PutApiV1UsersId(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusInternalServerError, statusCode)
+	})
+}


### PR DESCRIPTION
## Summary

- `POST /api/v1/date_spots` ハンドラーで `input.Validate()` を `Execute` 前に呼び出すよう修正
- `PUT /api/v1/date_spots/:id` ハンドラーに同様の修正を追加
- `opening_time`・`closing_time` が無効な形式の場合、サイレントに `nil` を渡す代わりに 422 を即時返却するよう変更

## Test plan

- [x] `go test ./...` がすべて通ること
- [x] `error_missing_name` / `error_missing_genre_id` / `error_missing_city_name` / `error_invalid_opening_time_format` が 422 を返すこと
- [x] 成功ケースが引き続き 201/200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)