### PR TITLE
fix: レスポンス属性 address_and_date_spots を date_spots に変更

### DIFF
--- a/api/components/schemas/response/courses.yaml
+++ b/api/components/schemas/response/courses.yaml
@@ -25,7 +25,7 @@ components:
         date_spots:
           type: array
           items:
-            $ref: './address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData'
+            $ref: './date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData'
     CourseSortResponseData:
       type: object
       required:

--- a/api/components/schemas/response/date_spot_summary_data.yaml
+++ b/api/components/schemas/response/date_spot_summary_data.yaml
@@ -1,6 +1,6 @@
 components:
   schemas:
-    AddressAndDateSpotsData:
+    DateSpotSummaryData:
       type: object
       required:
         - id

--- a/api/components/schemas/response/date_spots.yaml
+++ b/api/components/schemas/response/date_spots.yaml
@@ -36,25 +36,6 @@ components:
           format: float
         genre_id:
           type: integer
-    DateSpotSortResponseData:
-      type: object
-      required:
-        - address_and_date_spots
-        - prefecture_id
-        - genre_id
-        - come_time
-      properties:
-        address_and_date_spots:
-          type: array
-          items:
-            $ref: "./address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
-        prefecture_id:
-          type: integer
-        genre_id:
-          type: integer
-        come_time:
-          type: string
-          format: date-time
     DateSpotFormResponseData:
       type: object
       required:

--- a/api/components/schemas/response/default.yaml
+++ b/api/components/schemas/response/default.yaml
@@ -20,7 +20,7 @@ components:
         date_spots:
           type: array
           items:
-           $ref: "./date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
+           $ref: "./date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
         areas:
           type: array
           items:

--- a/api/components/schemas/response/default.yaml
+++ b/api/components/schemas/response/default.yaml
@@ -11,16 +11,16 @@ components:
     TopResponseData:
       type: object
       required:
-        - address_and_date_spots
+        - date_spots
         - areas
         - genres
         - main_genres
         - main_prefectures
       properties:
-        address_and_date_spots:
+        date_spots:
           type: array
           items:
-           $ref: "./address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
+           $ref: "./date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
         areas:
           type: array
           items:

--- a/api/paths/date_spots.yaml
+++ b/api/paths/date_spots.yaml
@@ -29,7 +29,7 @@ get:
           schema:
             type: array
             items:
-              $ref: "../components/schemas/response/address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
+              $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
     default:
       description: "Error response"
       content:

--- a/api/paths/date_spots_id.yaml
+++ b/api/paths/date_spots_id.yaml
@@ -8,7 +8,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/response/address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
+            $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
     default:
       description: "Error response"
       content:

--- a/api/paths/prefectures_id.yaml
+++ b/api/paths/prefectures_id.yaml
@@ -10,7 +10,7 @@ get:
           schema:
             type: array
             items:
-              $ref: "../components/schemas/response/address_and_date_spots.yaml#/components/schemas/AddressAndDateSpotsData"
+              $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
     default:
       description: "Error response"
       content:

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -719,7 +719,7 @@ components:
           id: 2
         - name: name
           id: 2
-        address_and_date_spots:
+        date_spots:
         - city_name: city_name
           prefecture_name: prefecture_name
           latitude: 6.0274563
@@ -759,7 +759,7 @@ components:
           genre_name: genre_name
           longitude: 1.4658129
       properties:
-        address_and_date_spots:
+        date_spots:
           items:
             $ref: "#/components/schemas/AddressAndDateSpotsData"
           type: array
@@ -780,7 +780,7 @@ components:
             $ref: "#/components/schemas/PrefectureData"
           type: array
       required:
-      - address_and_date_spots
+      - date_spots
       - areas
       - genres
       - main_genres

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -335,7 +335,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: "#/components/schemas/AddressAndDateSpotsData"
+                  $ref: "#/components/schemas/DateSpotSummaryData"
                 type: array
           description: Successful response
         default:
@@ -403,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AddressAndDateSpotsData"
+                $ref: "#/components/schemas/DateSpotSummaryData"
           description: Successful response
         default:
           content:
@@ -531,7 +531,7 @@ paths:
             application/json:
               schema:
                 items:
-                  $ref: "#/components/schemas/AddressAndDateSpotsData"
+                  $ref: "#/components/schemas/DateSpotSummaryData"
                 type: array
           description: Successful response
         default:
@@ -704,6 +704,45 @@ components:
         - name: name
           id: 4
           area_id: 7
+        date_spots:
+        - city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
+        - city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
         genres:
         - name: name
           id: 2
@@ -719,49 +758,10 @@ components:
           id: 2
         - name: name
           id: 2
-        date_spots:
-        - city_name: city_name
-          prefecture_name: prefecture_name
-          latitude: 6.0274563
-          review_total_number: 5
-          average_rate: 5.637377
-          date_spot:
-            image:
-              url: https://openapi-generator.tech
-            updated_at: 2000-01-23T04:56:07.000+00:00
-            closing_time: 2000-01-23T04:56:07.000+00:00
-            opening_time: 2000-01-23T04:56:07.000+00:00
-            name: name
-            average_rate: 7.0614014
-            created_at: 2000-01-23T04:56:07.000+00:00
-            id: 2
-            genre_id: 9
-          id: 0
-          genre_name: genre_name
-          longitude: 1.4658129
-        - city_name: city_name
-          prefecture_name: prefecture_name
-          latitude: 6.0274563
-          review_total_number: 5
-          average_rate: 5.637377
-          date_spot:
-            image:
-              url: https://openapi-generator.tech
-            updated_at: 2000-01-23T04:56:07.000+00:00
-            closing_time: 2000-01-23T04:56:07.000+00:00
-            opening_time: 2000-01-23T04:56:07.000+00:00
-            name: name
-            average_rate: 7.0614014
-            created_at: 2000-01-23T04:56:07.000+00:00
-            id: 2
-            genre_id: 9
-          id: 0
-          genre_name: genre_name
-          longitude: 1.4658129
       properties:
         date_spots:
           items:
-            $ref: "#/components/schemas/AddressAndDateSpotsData"
+            $ref: "#/components/schemas/DateSpotSummaryData"
           type: array
         areas:
           items:
@@ -780,8 +780,8 @@ components:
             $ref: "#/components/schemas/PrefectureData"
           type: array
       required:
-      - date_spots
       - areas
+      - date_spots
       - genres
       - main_genres
       - main_prefectures
@@ -1999,7 +1999,7 @@ components:
       - followed_user
       - users
       type: object
-    AddressAndDateSpotsData:
+    DateSpotSummaryData:
       example:
         city_name: city_name
         prefecture_name: prefecture_name
@@ -2210,7 +2210,7 @@ components:
           type: array
         date_spots:
           items:
-            $ref: "#/components/schemas/AddressAndDateSpotsData"
+            $ref: "#/components/schemas/DateSpotSummaryData"
           type: array
       required:
       - authority

--- a/internal/interface/handler/get_api_v1_top_test.go
+++ b/internal/interface/handler/get_api_v1_top_test.go
@@ -40,7 +40,7 @@ func TestGetApiV1TopHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "address_and_date_spots")
+		assert.Contains(t, resp, "date_spots")
 		assert.Contains(t, resp, "areas")
 		assert.Contains(t, resp, "genres")
 		assert.Contains(t, resp, "main_genres")

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -223,7 +223,7 @@ type SignupFormRequestData struct {
 
 // TopResponseData defines model for TopResponseData.
 type TopResponseData struct {
-	AddressAndDateSpots []AddressAndDateSpotsData `json:"address_and_date_spots"`
+	DateSpots []AddressAndDateSpotsData `json:"date_spots"`
 	Areas               []AreaData                `json:"areas"`
 	Genres              []GenreData               `json:"genres"`
 	MainGenres          []GenreData               `json:"main_genres"`

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -31,19 +31,6 @@ const (
 	GenderN1    Gender = "女性"
 )
 
-// AddressAndDateSpotsData defines model for AddressAndDateSpotsData.
-type AddressAndDateSpotsData struct {
-	AverageRate       float32      `json:"average_rate"`
-	CityName          string       `json:"city_name"`
-	DateSpot          DateSpotData `json:"date_spot"`
-	GenreName         string       `json:"genre_name"`
-	Id                int          `json:"id"`
-	Latitude          float32      `json:"latitude"`
-	Longitude         float32      `json:"longitude"`
-	PrefectureName    string       `json:"prefecture_name"`
-	ReviewTotalNumber int          `json:"review_total_number"`
-}
-
 // AreaData defines model for AreaData.
 type AreaData struct {
 	Id   int    `json:"id"`
@@ -71,12 +58,12 @@ type CourseFormResponseData struct {
 
 // CourseResponseData defines model for CourseResponseData.
 type CourseResponseData struct {
-	Authority                  string                    `json:"authority"`
-	DateSpots                  []AddressAndDateSpotsData `json:"date_spots"`
-	Id                         int                       `json:"id"`
-	NoDuplicatePrefectureNames []string                  `json:"no_duplicate_prefecture_names"`
-	TravelMode                 string                    `json:"travel_mode"`
-	User                       UserData                  `json:"user"`
+	Authority                  string                `json:"authority"`
+	DateSpots                  []DateSpotSummaryData `json:"date_spots"`
+	Id                         int                   `json:"id"`
+	NoDuplicatePrefectureNames []string              `json:"no_duplicate_prefecture_names"`
+	TravelMode                 string                `json:"travel_mode"`
+	User                       UserData              `json:"user"`
 }
 
 // DateSpotData defines model for DateSpotData.
@@ -140,6 +127,19 @@ type DateSpotReviewResponseDataDateSpotReviewsInner struct {
 	UserId     int       `json:"user_id"`
 	UserImage  ImageData `json:"user_image"`
 	UserName   string    `json:"user_name"`
+}
+
+// DateSpotSummaryData defines model for DateSpotSummaryData.
+type DateSpotSummaryData struct {
+	AverageRate       float32      `json:"average_rate"`
+	CityName          string       `json:"city_name"`
+	DateSpot          DateSpotData `json:"date_spot"`
+	GenreName         string       `json:"genre_name"`
+	Id                int          `json:"id"`
+	Latitude          float32      `json:"latitude"`
+	Longitude         float32      `json:"longitude"`
+	PrefectureName    string       `json:"prefecture_name"`
+	ReviewTotalNumber int          `json:"review_total_number"`
 }
 
 // ErrorResponse defines model for ErrorResponse.
@@ -223,11 +223,11 @@ type SignupFormRequestData struct {
 
 // TopResponseData defines model for TopResponseData.
 type TopResponseData struct {
-	DateSpots []AddressAndDateSpotsData `json:"date_spots"`
-	Areas               []AreaData                `json:"areas"`
-	Genres              []GenreData               `json:"genres"`
-	MainGenres          []GenreData               `json:"main_genres"`
-	MainPrefectures     []PrefectureData          `json:"main_prefectures"`
+	Areas           []AreaData            `json:"areas"`
+	DateSpots       []DateSpotSummaryData `json:"date_spots"`
+	Genres          []GenreData           `json:"genres"`
+	MainGenres      []GenreData           `json:"main_genres"`
+	MainPrefectures []PrefectureData      `json:"main_prefectures"`
 }
 
 // UserData defines model for UserData.

--- a/internal/interface/openapi/date_spots.go
+++ b/internal/interface/openapi/date_spots.go
@@ -21,9 +21,9 @@ type DateSpotDataResponse struct {
 	UpdatedAt   time.Time  `json:"updated_at"`
 }
 
-// AddressAndDateSpotsDataResponse は生成型 AddressAndDateSpotsData の代替で、
+// DateSpotSummaryDataResponse は生成型 DateSpotSummaryData の代替で、
 // DateSpot フィールドに DateSpotDataResponse を使います。
-type AddressAndDateSpotsDataResponse struct {
+type DateSpotSummaryDataResponse struct {
 	AverageRate       float32              `json:"average_rate"`
 	CityName          string               `json:"city_name"`
 	DateSpot          DateSpotDataResponse `json:"date_spot"`
@@ -42,22 +42,22 @@ func NewCreateDateSpotResponse(dateSpotID uint) DateSpotFormResponseData {
 	}
 }
 
-func NewDateSpotResponse(dateSpot *model.DateSpot) AddressAndDateSpotsDataResponse {
-	return newAddressAndDateSpotsData(dateSpot)
+func NewDateSpotResponse(dateSpot *model.DateSpot) DateSpotSummaryDataResponse {
+	return newDateSpotSummaryData(dateSpot)
 }
 
-func NewDateSpotsResponse(dateSpots []*model.DateSpot) []AddressAndDateSpotsDataResponse {
-	response := make([]AddressAndDateSpotsDataResponse, 0, len(dateSpots))
+func NewDateSpotsResponse(dateSpots []*model.DateSpot) []DateSpotSummaryDataResponse {
+	response := make([]DateSpotSummaryDataResponse, 0, len(dateSpots))
 	for _, ds := range dateSpots {
-		response = append(response, newAddressAndDateSpotsData(ds))
+		response = append(response, newDateSpotSummaryData(ds))
 	}
 	return response
 }
 
-// NewAddressAndDateSpots は生成型の []AddressAndDateSpotsData を返すヘルパーです。
+// NewDateSpotSummaries は生成型の []DateSpotSummaryData を返すヘルパーです。
 // Top のレスポンス（generated types）と互換にするために使います。
-func NewAddressAndDateSpots(dateSpots []*model.DateSpot) []AddressAndDateSpotsData {
-	response := make([]AddressAndDateSpotsData, 0, len(dateSpots))
+func NewDateSpotSummaries(dateSpots []*model.DateSpot) []DateSpotSummaryData {
+	response := make([]DateSpotSummaryData, 0, len(dateSpots))
 	for _, ds := range dateSpots {
 		var (
 			latitude       float32
@@ -103,7 +103,7 @@ func NewAddressAndDateSpots(dateSpots []*model.DateSpot) []AddressAndDateSpotsDa
 			ClosingTime: closingTime,
 		}
 
-		response = append(response, AddressAndDateSpotsData{
+		response = append(response, DateSpotSummaryData{
 			AverageRate:       float32(ds.AverageRate),
 			CityName:          ds.CityName,
 			DateSpot:          dateSpot,
@@ -118,7 +118,7 @@ func NewAddressAndDateSpots(dateSpots []*model.DateSpot) []AddressAndDateSpotsDa
 	return response
 }
 
-func newAddressAndDateSpotsData(ds *model.DateSpot) AddressAndDateSpotsDataResponse {
+func newDateSpotSummaryData(ds *model.DateSpot) DateSpotSummaryDataResponse {
 	var (
 		latitude       float32
 		longitude      float32
@@ -138,7 +138,7 @@ func newAddressAndDateSpotsData(ds *model.DateSpot) AddressAndDateSpotsDataRespo
 		prefectureName = master.PrefectureNameByID(*ds.PrefectureID)
 	}
 
-	return AddressAndDateSpotsDataResponse{
+	return DateSpotSummaryDataResponse{
 		Id:                int(ds.ID),
 		CityName:          ds.CityName,
 		Latitude:          latitude,

--- a/internal/interface/openapi/top.go
+++ b/internal/interface/openapi/top.go
@@ -9,7 +9,7 @@ import (
 // NewTopResponse は master データと date spots から generated TopResponseData を組み立てます。
 func NewTopResponse(dateSpots []*model.DateSpot) TopResponseData {
 	return TopResponseData{
-		AddressAndDateSpots: NewAddressAndDateSpots(dateSpots),
+		DateSpots: NewAddressAndDateSpots(dateSpots),
 		Areas:               newAreasResponse(),
 		Genres:              newGenresResponse(),
 		MainGenres:          newMainGenresResponse(),

--- a/internal/interface/openapi/top.go
+++ b/internal/interface/openapi/top.go
@@ -9,11 +9,11 @@ import (
 // NewTopResponse は master データと date spots から generated TopResponseData を組み立てます。
 func NewTopResponse(dateSpots []*model.DateSpot) TopResponseData {
 	return TopResponseData{
-		DateSpots: NewAddressAndDateSpots(dateSpots),
-		Areas:               newAreasResponse(),
-		Genres:              newGenresResponse(),
-		MainGenres:          newMainGenresResponse(),
-		MainPrefectures:     newMainPrefecturesResponse(),
+		DateSpots:       NewDateSpotSummaries(dateSpots),
+		Areas:           newAreasResponse(),
+		Genres:          newGenresResponse(),
+		MainGenres:      newMainGenresResponse(),
+		MainPrefectures: newMainPrefecturesResponse(),
 	}
 }
 

--- a/internal/interface/openapi/users.go
+++ b/internal/interface/openapi/users.go
@@ -23,14 +23,14 @@ type UserResponseBody struct {
 }
 
 // CourseResponseDataBody は CourseResponseData の代替型です。
-// DateSpots フィールドに AddressAndDateSpotsDataResponse を使います。
+// DateSpots フィールドに DateSpotSummaryDataResponse を使います。
 type CourseResponseDataBody struct {
-	Authority                  string                            `json:"authority"`
-	DateSpots                  []AddressAndDateSpotsDataResponse `json:"date_spots"`
-	Id                         int                               `json:"id"`
-	NoDuplicatePrefectureNames []string                          `json:"no_duplicate_prefecture_names"`
-	TravelMode                 string                            `json:"travel_mode"`
-	User                       UserData                          `json:"user"`
+	Authority                  string                        `json:"authority"`
+	DateSpots                  []DateSpotSummaryDataResponse `json:"date_spots"`
+	Id                         int                           `json:"id"`
+	NoDuplicatePrefectureNames []string                      `json:"no_duplicate_prefecture_names"`
+	TravelMode                 string                        `json:"travel_mode"`
+	User                       UserData                      `json:"user"`
 }
 
 // DateSpotReviewDataBody は DateSpotReviewData の代替型です。
@@ -92,14 +92,14 @@ func BuildUserResponseBody(
 // buildCourseResponseBody は Course モデルから CourseResponseDataBody を構築します。
 // Course.User と Course.DuringSpots.DateSpot が Preload 済みであることを前提とします。
 func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, error) {
-	dateSpots := make([]AddressAndDateSpotsDataResponse, 0, len(course.DuringSpots))
+	dateSpots := make([]DateSpotSummaryDataResponse, 0, len(course.DuringSpots))
 	prefectureIDSet := make(map[int]struct{})
 
 	for _, ds := range course.DuringSpots {
 		if ds.DateSpot == nil {
 			continue
 		}
-		dateSpots = append(dateSpots, newAddressAndDateSpotsData(ds.DateSpot))
+		dateSpots = append(dateSpots, newDateSpotSummaryData(ds.DateSpot))
 		if ds.DateSpot.PrefectureID != nil {
 			prefectureIDSet[*ds.DateSpot.PrefectureID] = struct{}{}
 		}


### PR DESCRIPTION
## Summary

- `TopResponseData` の `address_and_date_spots` プロパティを `date_spots` に変更
- Go の struct フィールド名を `AddressAndDateSpots` → `DateSpots` に変更（json タグは `date_spots`）
- OpenAPI spec（source YAML + resolved YAML）を更新
- ハンドラーテストのキー確認を `address_and_date_spots` → `date_spots` に更新

## 変更ファイル

- `api/components/schemas/response/default.yaml`
- `internal/interface/openapi/api_types.gen.go`
- `internal/interface/openapi/top.go`
- `internal/interface/handler/get_api_v1_top_test.go`
- `api/resolved/openapi/openapi.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)