### PR TITLE
fix: GET /api/v1/date_spots/:id のレスポンスを Rails に合わせて修正

### DIFF
--- a/api/components/schemas/response/date_spot_review.yaml
+++ b/api/components/schemas/response/date_spot_review.yaml
@@ -20,17 +20,18 @@ components:
     DateSpotReviewResponseData:
       type: object
       required:
+        - date_spot
         - date_spot_reviews
         - review_average_rate
       properties:
+        date_spot:
+          $ref: "./date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
         date_spot_reviews:
           type: array
           items:
             type: object
             required:
               - id
-              - rate
-              - content
               - user_id
               - date_spot_id
               - user_name
@@ -42,8 +43,10 @@ components:
               rate:
                 type: number
                 format: float
+                nullable: true
               content:
                 type: string
+                nullable: true
               user_id:
                 type: integer
               date_spot_id:
@@ -55,5 +58,5 @@ components:
               user_image:
                 $ref: "./image.yaml#/components/schemas/ImageData"
         review_average_rate:
-          type: integer
+          type: number
           format: float

--- a/api/paths/date_spots_id.yaml
+++ b/api/paths/date_spots_id.yaml
@@ -8,7 +8,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
+            $ref: "../components/schemas/response/date_spot_review.yaml#/components/schemas/DateSpotReviewResponseData"
     default:
       description: "Error response"
       content:

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -403,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DateSpotSummaryData"
+                $ref: "#/components/schemas/DateSpotReviewResponseData"
           description: Successful response
         default:
           content:
@@ -2089,6 +2089,63 @@ components:
       required:
       - date_spot_id
       type: object
+    DateSpotReviewResponseData:
+      example:
+        review_average_rate: 5.637377
+        date_spot:
+          city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
+        date_spot_reviews:
+        - rate: 6.0274563
+          user_id: 1
+          user_image:
+            url: https://openapi-generator.tech
+          user_name: user_name
+          date_spot_id: 5
+          user_gender: user_gender
+          id: 0
+          content: content
+        - rate: 6.0274563
+          user_id: 1
+          user_image:
+            url: https://openapi-generator.tech
+          user_name: user_name
+          date_spot_id: 5
+          user_gender: user_gender
+          id: 0
+          content: content
+      properties:
+        date_spot:
+          $ref: "#/components/schemas/DateSpotSummaryData"
+        date_spot_reviews:
+          items:
+            $ref: "#/components/schemas/DateSpotReviewResponseData_date_spot_reviews_inner"
+          type: array
+        review_average_rate:
+          format: float
+          type: number
+      required:
+      - date_spot
+      - date_spot_reviews
+      - review_average_rate
+      type: object
     DateSpotReviewFormRequestData:
       properties:
         rate:
@@ -2105,40 +2162,6 @@ components:
       - date_spot_id
       - rate
       - user_id
-      type: object
-    DateSpotReviewResponseData:
-      example:
-        review_average_rate: 5
-        date_spot_reviews:
-        - rate: 6.0274563
-          user_id: 1
-          user_image:
-            url: https://openapi-generator.tech
-          user_name: user_name
-          date_spot_id: 5
-          user_gender: user_gender
-          id: 0
-          content: content
-        - rate: 6.0274563
-          user_id: 1
-          user_image:
-            url: https://openapi-generator.tech
-          user_name: user_name
-          date_spot_id: 5
-          user_gender: user_gender
-          id: 0
-          content: content
-      properties:
-        date_spot_reviews:
-          items:
-            $ref: "#/components/schemas/DateSpotReviewResponseData_date_spot_reviews_inner"
-          type: array
-        review_average_rate:
-          format: float
-          type: integer
-      required:
-      - date_spot_reviews
-      - review_average_rate
       type: object
     CourseResponseData:
       example:
@@ -2447,8 +2470,10 @@ components:
           type: integer
         rate:
           format: float
+          nullable: true
           type: number
         content:
+          nullable: true
           type: string
         user_id:
           type: integer
@@ -2461,10 +2486,8 @@ components:
         user_image:
           $ref: "#/components/schemas/ImageData"
       required:
-      - content
       - date_spot_id
       - id
-      - rate
       - user_gender
       - user_id
       - user_image

--- a/internal/domain/repository/date_spot_review_repository.go
+++ b/internal/domain/repository/date_spot_review_repository.go
@@ -9,6 +9,7 @@ import (
 type DateSpotReviewRepository interface {
 	Create(ctx context.Context, review *model.DateSpotReview) error
 	FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error)
+	FindByDateSpotID(ctx context.Context, dateSpotID uint) ([]*model.DateSpotReview, error)
 	DeleteByID(ctx context.Context, id uint) error
 	UpdateByID(ctx context.Context, id uint, review *model.DateSpotReview) error
 }

--- a/internal/domain/repository/mock/date_spot_review_repository.go
+++ b/internal/domain/repository/mock/date_spot_review_repository.go
@@ -69,6 +69,21 @@ func (mr *MockDateSpotReviewRepositoryMockRecorder) DeleteByID(ctx, id any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).DeleteByID), ctx, id)
 }
 
+// FindByDateSpotID mocks base method.
+func (m *MockDateSpotReviewRepository) FindByDateSpotID(ctx context.Context, dateSpotID uint) ([]*model.DateSpotReview, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByDateSpotID", ctx, dateSpotID)
+	ret0, _ := ret[0].([]*model.DateSpotReview)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByDateSpotID indicates an expected call of FindByDateSpotID.
+func (mr *MockDateSpotReviewRepositoryMockRecorder) FindByDateSpotID(ctx, dateSpotID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByDateSpotID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).FindByDateSpotID), ctx, dateSpotID)
+}
+
 // FindByUserID mocks base method.
 func (m *MockDateSpotReviewRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error) {
 	m.ctrl.T.Helper()

--- a/internal/infrastructure/persistence/date_spot_review_repository.go
+++ b/internal/infrastructure/persistence/date_spot_review_repository.go
@@ -35,6 +35,19 @@ func (r *dateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) erro
 	return nil
 }
 
+// FindByDateSpotID は指定 DateSpot のレビュー一覧を User 込みで返します。
+func (r *dateSpotReviewRepository) FindByDateSpotID(ctx context.Context, dateSpotID uint) ([]*model.DateSpotReview, error) {
+	var reviews []*model.DateSpotReview
+	if err := r.db.WithContext(ctx).
+		Where("date_spot_id = ?", dateSpotID).
+		Preload("User").
+		Find(&reviews).Error; err != nil {
+		slog.ErrorContext(ctx, "dateSpotReviewRepository.FindByDateSpotID failed", "err", err)
+		return nil, err
+	}
+	return reviews, nil
+}
+
 // FindByUserID は指定ユーザーのレビュー一覧を DateSpot 込みで返します。
 func (r *dateSpotReviewRepository) FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error) {
 	var reviews []*model.DateSpotReview

--- a/internal/interface/handler/get_api_v1_date_spots_id.go
+++ b/internal/interface/handler/get_api_v1_date_spots_id.go
@@ -20,5 +20,5 @@ func (h *GetApiV1DateSpotsIdHandler) GetApiV1DateSpotsId(ctx echo.Context, id in
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, openapi.NewDateSpotResponse(output.DateSpot))
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
 }

--- a/internal/interface/handler/get_api_v1_date_spots_id_test.go
+++ b/internal/interface/handler/get_api_v1_date_spots_id_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
@@ -18,15 +19,30 @@ import (
 )
 
 func TestGetApiV1DateSpotsIdHandler(t *testing.T) {
-	t.Run("success_returns_200_with_date_spot", func(t *testing.T) {
+	t.Run("success_returns_200_with_date_spot_reviews_and_average_rate", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		dateSpot := dummyDateSpot(1, "東京タワー")
+		rate := 4.0
+		content := "良かった"
+		userName := "田中"
+		gender := model.GenderMale
+		reviews := []*model.DateSpotReview{
+			{
+				ID:         1,
+				DateSpotID: 1,
+				UserID:     1,
+				Rate:       &rate,
+				Content:    &content,
+				User:       &model.User{ID: 1, Name: userName, Gender: gender},
+			},
+		}
+
 		mockPort := usecasemock.NewMockGetDateSpotInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), usecase.GetDateSpotInput{ID: 1}).
-			Return(&usecase.GetDateSpotOutput{DateSpot: dateSpot}, nil)
+			Return(&usecase.GetDateSpotOutput{DateSpot: dateSpot, DateSpotReviews: reviews}, nil)
 
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/date_spots/1", nil)
@@ -41,7 +57,13 @@ func TestGetApiV1DateSpotsIdHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, float64(1), resp["id"])
+		assert.Contains(t, resp, "date_spot")
+		assert.Contains(t, resp, "review_average_rate")
+		assert.Contains(t, resp, "date_spot_reviews")
+
+		reviewsList, ok := resp["date_spot_reviews"].([]interface{})
+		require.True(t, ok)
+		assert.Len(t, reviewsList, 1)
 	})
 
 	t.Run("error_not_found", func(t *testing.T) {

--- a/internal/interface/handler/get_api_v1_top_test.go
+++ b/internal/interface/handler/get_api_v1_top_test.go
@@ -44,7 +44,7 @@ func TestGetApiV1TopHandler(t *testing.T) {
 		assert.Contains(t, resp, "areas")
 		assert.Contains(t, resp, "genres")
 		assert.Contains(t, resp, "main_genres")
-		assert.Contains(t, resp, "main_prefecture")
+		assert.Contains(t, resp, "main_prefectures")
 	})
 
 	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -113,16 +113,17 @@ type DateSpotReviewFormRequestData struct {
 
 // DateSpotReviewResponseData defines model for DateSpotReviewResponseData.
 type DateSpotReviewResponseData struct {
+	DateSpot          DateSpotSummaryData                              `json:"date_spot"`
 	DateSpotReviews   []DateSpotReviewResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
-	ReviewAverageRate int                                              `json:"review_average_rate"`
+	ReviewAverageRate float32                                          `json:"review_average_rate"`
 }
 
 // DateSpotReviewResponseDataDateSpotReviewsInner defines model for DateSpotReviewResponseData_date_spot_reviews_inner.
 type DateSpotReviewResponseDataDateSpotReviewsInner struct {
-	Content    string    `json:"content"`
+	Content    *string   `json:"content"`
 	DateSpotId int       `json:"date_spot_id"`
 	Id         int       `json:"id"`
-	Rate       float32   `json:"rate"`
+	Rate       *float32  `json:"rate"`
 	UserGender string    `json:"user_gender"`
 	UserId     int       `json:"user_id"`
 	UserImage  ImageData `json:"user_image"`

--- a/internal/interface/openapi/date_spots.go
+++ b/internal/interface/openapi/date_spots.go
@@ -35,6 +35,54 @@ type DateSpotSummaryDataResponse struct {
 	ReviewTotalNumber int                  `json:"review_total_number"`
 }
 
+// DateSpotShowResponse は GET /api/v1/date_spots/:id のレスポンス型です。
+type DateSpotShowResponse struct {
+	DateSpot          DateSpotSummaryDataResponse `json:"date_spot"`
+	ReviewAverageRate float64                     `json:"review_average_rate"`
+	DateSpotReviews   []DateSpotReviewItem        `json:"date_spot_reviews"`
+}
+
+// DateSpotReviewItem はレビュー一覧の各要素です。
+type DateSpotReviewItem struct {
+	Id         int       `json:"id"`
+	Rate       *float64  `json:"rate"`
+	Content    *string   `json:"content"`
+	UserId     int       `json:"user_id"`
+	DateSpotId int       `json:"date_spot_id"`
+	UserName   string    `json:"user_name"`
+	UserGender string    `json:"user_gender"`
+	UserImage  ImageData `json:"user_image"`
+}
+
+// NewDateSpotShowResponse は DateSpot とレビュー一覧から DateSpotShowResponse を構築します。
+func NewDateSpotShowResponse(dateSpot *model.DateSpot, reviews []*model.DateSpotReview) DateSpotShowResponse {
+	return DateSpotShowResponse{
+		DateSpot:          newDateSpotSummaryData(dateSpot),
+		ReviewAverageRate: dateSpot.AverageRate,
+		DateSpotReviews:   newDateSpotReviewItems(reviews),
+	}
+}
+
+func newDateSpotReviewItems(reviews []*model.DateSpotReview) []DateSpotReviewItem {
+	items := make([]DateSpotReviewItem, 0, len(reviews))
+	for _, r := range reviews {
+		item := DateSpotReviewItem{
+			Id:         int(r.ID),
+			Rate:       r.Rate,
+			Content:    r.Content,
+			UserId:     int(r.UserID),
+			DateSpotId: int(r.DateSpotID),
+		}
+		if r.User != nil {
+			item.UserName = r.User.Name
+			item.UserGender = string(r.User.Gender)
+			item.UserImage = ImageData{Url: r.User.Image}
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
 // NewCreateDateSpotResponse は DateSpotID から DateSpotFormResponseData を構築します。
 func NewCreateDateSpotResponse(dateSpotID uint) DateSpotFormResponseData {
 	return DateSpotFormResponseData{

--- a/internal/usecase/get_date_spot.go
+++ b/internal/usecase/get_date_spot.go
@@ -16,16 +16,22 @@ type GetDateSpotInput struct {
 }
 
 type GetDateSpotOutput struct {
-	DateSpot *model.DateSpot
+	DateSpot        *model.DateSpot
+	DateSpotReviews []*model.DateSpotReview
 }
 
 type GetDateSpotInteractor struct {
-	DateSpotRepository repository.DateSpotRepository
+	DateSpotRepository       repository.DateSpotRepository
+	DateSpotReviewRepository repository.DateSpotReviewRepository
 }
 
-func NewGetDateSpotUsecase(dateSpotRepository repository.DateSpotRepository) GetDateSpotInputPort {
+func NewGetDateSpotUsecase(
+	dateSpotRepository repository.DateSpotRepository,
+	dateSpotReviewRepository repository.DateSpotReviewRepository,
+) GetDateSpotInputPort {
 	return &GetDateSpotInteractor{
-		DateSpotRepository: dateSpotRepository,
+		DateSpotRepository:       dateSpotRepository,
+		DateSpotReviewRepository: dateSpotReviewRepository,
 	}
 }
 
@@ -34,5 +40,11 @@ func (i *GetDateSpotInteractor) Execute(ctx context.Context, input GetDateSpotIn
 	if err != nil {
 		return nil, err
 	}
-	return &GetDateSpotOutput{DateSpot: dateSpot}, nil
+
+	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, input.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GetDateSpotOutput{DateSpot: dateSpot, DateSpotReviews: reviews}, nil
 }

--- a/internal/usecase/get_date_spot_test.go
+++ b/internal/usecase/get_date_spot_test.go
@@ -20,18 +20,25 @@ func TestGetDateSpotInteractor_Execute(t *testing.T) {
 
 		ctx := context.Background()
 		dateSpot := &model.DateSpot{ID: 1, Name: "東京タワー", CityName: "港区"}
+		reviews := []*model.DateSpotReview{{ID: 1, DateSpotID: 1}}
 
 		dateSpotRepo := repositorymock.NewMockDateSpotRepository(ctrl)
 		dateSpotRepo.EXPECT().
 			FindByID(ctx, uint(1)).
 			Return(dateSpot, nil)
 
-		interactor := usecase.NewGetDateSpotUsecase(dateSpotRepo)
+		reviewRepo := repositorymock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(1)).
+			Return(reviews, nil)
+
+		interactor := usecase.NewGetDateSpotUsecase(dateSpotRepo, reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.GetDateSpotInput{ID: 1})
 
 		require.NoError(t, err)
 		require.NotNil(t, output)
 		assert.Equal(t, dateSpot, output.DateSpot)
+		assert.Equal(t, reviews, output.DateSpotReviews)
 	})
 
 	t.Run("error_not_found", func(t *testing.T) {
@@ -45,7 +52,9 @@ func TestGetDateSpotInteractor_Execute(t *testing.T) {
 			FindByID(ctx, uint(999)).
 			Return(nil, apperror.NotFound())
 
-		interactor := usecase.NewGetDateSpotUsecase(dateSpotRepo)
+		reviewRepo := repositorymock.NewMockDateSpotReviewRepository(ctrl)
+
+		interactor := usecase.NewGetDateSpotUsecase(dateSpotRepo, reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.GetDateSpotInput{ID: 999})
 
 		assert.Error(t, err)
@@ -53,5 +62,29 @@ func TestGetDateSpotInteractor_Execute(t *testing.T) {
 		statusCode, _, _, ok := apperror.HTTPStatus(err)
 		assert.True(t, ok)
 		assert.Equal(t, 404, statusCode)
+	})
+
+	t.Run("error_reviews_fetch_fails", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		ctx := context.Background()
+		dateSpot := &model.DateSpot{ID: 1, Name: "東京タワー", CityName: "港区"}
+
+		dateSpotRepo := repositorymock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			FindByID(ctx, uint(1)).
+			Return(dateSpot, nil)
+
+		reviewRepo := repositorymock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(1)).
+			Return(nil, apperror.InternalServerError(nil))
+
+		interactor := usecase.NewGetDateSpotUsecase(dateSpotRepo, reviewRepo)
+		output, err := interactor.Execute(ctx, usecase.GetDateSpotInput{ID: 1})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
 	})
 }


### PR DESCRIPTION
## Summary

Rails の `DateSpotsController#show` に合わせて Go のレスポンス構造を修正。

**変更前**: `DateSpotSummaryData`（date_spot データのみ）を直接返す
**変更後**: `{ date_spot, review_average_rate, date_spot_reviews }` を返す

## 変更内容

### Repository
- `DateSpotReviewRepository` に `FindByDateSpotID` を追加（User を Preload）

### Usecase
- `GetDateSpotInteractor` が `DateSpotReviewRepository` を保持するよう変更
- `GetDateSpotOutput` に `DateSpotReviews` フィールドを追加

### OpenAPI
- `DateSpotReviewResponseData` に `date_spot` フィールドを追加
- `review_average_rate` の型を `integer` → `number` に修正
- GET `/api/v1/date_spots/{id}` のレスポンスを `DateSpotReviewResponseData` に変更

### Handler / Response
- `DateSpotShowResponse` / `DateSpotReviewItem` 構造体を追加
- `NewDateSpotShowResponse` ビルダー関数を追加

### Bug fix
- `get_api_v1_top_test.go` の `main_prefecture` タイポを `main_prefectures` に修正

## Test plan

- [x] `go test ./...` すべて通過
- [x] `go build ./...` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)