### PR TITLE
fix: OpenAPI レスポンススキーマを Rails の実装に合わせて修正

### DIFF
--- a/api/components/schemas/response/courses.yaml
+++ b/api/components/schemas/response/courses.yaml
@@ -43,5 +43,5 @@ components:
       required:
         - course_id
       properties:
-        date_spot_id:
+        course_id:
           type: integer

--- a/api/components/schemas/response/date_spot_review.yaml
+++ b/api/components/schemas/response/date_spot_review.yaml
@@ -1,5 +1,48 @@
 components:
   schemas:
+    DateSpotShowResponseData:
+      type: object
+      required:
+        - date_spot
+        - review_average_rate
+        - date_spot_reviews
+      properties:
+        date_spot:
+          $ref: "./date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
+        review_average_rate:
+          type: number
+          format: float
+        date_spot_reviews:
+          type: array
+          items:
+            type: object
+            required:
+              - id
+              - user_id
+              - date_spot_id
+              - user_name
+              - user_gender
+              - user_image
+            properties:
+              id:
+                type: integer
+              rate:
+                type: number
+                format: float
+                nullable: true
+              content:
+                type: string
+                nullable: true
+              user_id:
+                type: integer
+              date_spot_id:
+                type: integer
+              user_name:
+                type: string
+              user_gender:
+                type: string
+              user_image:
+                $ref: "./image.yaml#/components/schemas/ImageData"
     DateSpotReviewData:
       type: object
       required:

--- a/api/components/schemas/response/registration.yaml
+++ b/api/components/schemas/response/registration.yaml
@@ -8,7 +8,7 @@ components:
         - token
       properties:
         user:
-          $reg: "./user.yaml#/components/schemas/UserResponseData"
+          $ref: "./user.yaml#/components/schemas/UserResponseData"
         login_status:
           type: boolean
         token:

--- a/api/components/schemas/response/relationship.yaml
+++ b/api/components/schemas/response/relationship.yaml
@@ -32,7 +32,7 @@ components:
       required:
         - users
         - current_user
-        - followed_user
+        - unfollowed_user
       properties:
         users:
           type: array
@@ -40,5 +40,5 @@ components:
             $ref: "./user.yaml#/components/schemas/UserResponseData"
         current_user:
           $ref: "./user.yaml#/components/schemas/UserResponseData"
-        un_followed_user:
+        unfollowed_user:
           $ref: "./user.yaml#/components/schemas/UserResponseData"

--- a/api/components/schemas/response/session.yaml
+++ b/api/components/schemas/response/session.yaml
@@ -3,9 +3,12 @@ components:
     LoginResponseData:
       type: object
       required:
+        - user
         - login_status
         - token
       properties:
+        user:
+          $ref: "./user.yaml#/components/schemas/UserData"
         login_status:
           type: boolean
         token:

--- a/api/paths/courses.yaml
+++ b/api/paths/courses.yaml
@@ -12,7 +12,9 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/response/courses.yaml#/components/schemas/CourseResponseData"
+            type: array
+            items:
+              $ref: "../components/schemas/response/courses.yaml#/components/schemas/CourseResponseData"
     default:
       description: "Error response"
       content:

--- a/api/paths/courses_id.yaml
+++ b/api/paths/courses_id.yaml
@@ -8,9 +8,7 @@ get:
       content:
         application/json:
           schema:
-            type: array
-            items:
-              $ref: "../components/schemas/response/courses.yaml#/components/schemas/CourseResponseData"
+            $ref: "../components/schemas/response/courses.yaml#/components/schemas/CourseResponseData"
     default:
       description: "Error response"
       content:

--- a/api/paths/date_spots_id.yaml
+++ b/api/paths/date_spots_id.yaml
@@ -8,7 +8,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/response/date_spot_review.yaml#/components/schemas/DateSpotReviewResponseData"
+            $ref: "../components/schemas/response/date_spot_review.yaml#/components/schemas/DateSpotShowResponseData"
     default:
       description: "Error response"
       content:

--- a/api/paths/genres_id.yaml
+++ b/api/paths/genres_id.yaml
@@ -5,6 +5,17 @@ get:
   responses:
     "200":
       description: "Successful response"
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - address_and_date_spots
+            properties:
+              address_and_date_spots:
+                type: array
+                items:
+                  $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
     default:
       description: "Error response"
       content:

--- a/api/paths/relationships_current_user_id_other_user_id.yaml
+++ b/api/paths/relationships_current_user_id_other_user_id.yaml
@@ -11,7 +11,7 @@ delete:
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/response/relationship.yaml#/components/schemas/FollowResponseData"
+            $ref: "../components/schemas/response/relationship.yaml#/components/schemas/UnFollowResponseData"
     default:
       description: "Error response"
       content:

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -84,7 +84,7 @@ paths:
     post:
       requestBody:
         content:
-          application/json:
+          application/x-www-form-urlencoded:
             schema:
               $ref: "#/components/schemas/SigninFormRequestData"
         required: true
@@ -294,7 +294,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FollowResponseData"
+                $ref: "#/components/schemas/UnFollowResponseData"
           description: Successful response
         default:
           content:
@@ -403,7 +403,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DateSpotReviewResponseData"
+                $ref: "#/components/schemas/DateSpotShowResponseData"
           description: Successful response
         default:
           content:
@@ -552,6 +552,10 @@ paths:
           type: integer
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/_api_v1_genres__id__get_200_response"
           description: Successful response
         default:
           content:
@@ -574,7 +578,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CourseResponseData"
+                items:
+                  $ref: "#/components/schemas/CourseResponseData"
+                type: array
           description: Successful response
         default:
           content:
@@ -629,9 +635,7 @@ paths:
           content:
             application/json:
               schema:
-                items:
-                  $ref: "#/components/schemas/CourseResponseData"
-                type: array
+                $ref: "#/components/schemas/CourseResponseData"
           description: Successful response
         default:
           content:
@@ -811,23 +815,166 @@ components:
     SignUpResponseData:
       example:
         login_status: true
-        user: ""
-        token: token
+        user:
+          image:
+            url: https://openapi-generator.tech
+          courses:
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          gender: 男性
+          followerIds:
+          - 6
+          - 6
+          name: name
+          admin: true
+          followingIds:
+          - 1
+          - 1
+          id: 0
+          email: email
+          date_spot_reviews:
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
       properties:
-        user: {}
+        user:
+          $ref: "#/components/schemas/UserResponseData"
         login_status:
           type: boolean
-        token:
-          type: string
       required:
       - login_status
-      - token
       - user
       type: object
     SigninFormRequestData:
-      example:
-        password: password
-        name: name
       properties:
         name:
           type: string
@@ -840,8 +987,18 @@ components:
     LoginResponseData:
       example:
         login_status: true
+        user:
+          image:
+            url: https://openapi-generator.tech
+          gender: null
+          name: name
+          admin: true
+          id: 5
+          email: email
         token: token
       properties:
+        user:
+          $ref: "#/components/schemas/UserData"
         login_status:
           type: boolean
         token:
@@ -849,6 +1006,7 @@ components:
       required:
       - login_status
       - token
+      - user
       type: object
     UserResponseData:
       example:
@@ -2006,6 +2164,621 @@ components:
       - followed_user
       - users
       type: object
+    UnFollowResponseData:
+      example:
+        unfollowed_user:
+          image:
+            url: https://openapi-generator.tech
+          courses:
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          gender: 男性
+          followerIds:
+          - 6
+          - 6
+          name: name
+          admin: true
+          followingIds:
+          - 1
+          - 1
+          id: 0
+          email: email
+          date_spot_reviews:
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+        users:
+        - image:
+            url: https://openapi-generator.tech
+          courses:
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          gender: 男性
+          followerIds:
+          - 6
+          - 6
+          name: name
+          admin: true
+          followingIds:
+          - 1
+          - 1
+          id: 0
+          email: email
+          date_spot_reviews:
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+        - image:
+            url: https://openapi-generator.tech
+          courses:
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          gender: 男性
+          followerIds:
+          - 6
+          - 6
+          name: name
+          admin: true
+          followingIds:
+          - 1
+          - 1
+          id: 0
+          email: email
+          date_spot_reviews:
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+        current_user:
+          image:
+            url: https://openapi-generator.tech
+          courses:
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          - no_duplicate_prefecture_names:
+            - no_duplicate_prefecture_names
+            - no_duplicate_prefecture_names
+            date_spots:
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            - city_name: city_name
+              prefecture_name: prefecture_name
+              latitude: 6.0274563
+              review_total_number: 5
+              average_rate: 5.637377
+              date_spot:
+                image:
+                  url: https://openapi-generator.tech
+                updated_at: 2000-01-23T04:56:07.000+00:00
+                closing_time: 2000-01-23T04:56:07.000+00:00
+                opening_time: 2000-01-23T04:56:07.000+00:00
+                name: name
+                average_rate: 7.0614014
+                created_at: 2000-01-23T04:56:07.000+00:00
+                id: 2
+                genre_id: 9
+              id: 0
+              genre_name: genre_name
+              longitude: 1.4658129
+            travel_mode: travel_mode
+            authority: authority
+            id: 5
+            user:
+              image:
+                url: https://openapi-generator.tech
+              gender: null
+              name: name
+              admin: true
+              id: 5
+              email: email
+          gender: 男性
+          followerIds:
+          - 6
+          - 6
+          name: name
+          admin: true
+          followingIds:
+          - 1
+          - 1
+          id: 0
+          email: email
+          date_spot_reviews:
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+          - rate: 7.0614014
+            date_spot:
+              image:
+                url: https://openapi-generator.tech
+              updated_at: 2000-01-23T04:56:07.000+00:00
+              closing_time: 2000-01-23T04:56:07.000+00:00
+              opening_time: 2000-01-23T04:56:07.000+00:00
+              name: name
+              average_rate: 7.0614014
+              created_at: 2000-01-23T04:56:07.000+00:00
+              id: 2
+              genre_id: 9
+            id: 2
+            content: content
+      properties:
+        users:
+          items:
+            $ref: "#/components/schemas/UserResponseData"
+          type: array
+        current_user:
+          $ref: "#/components/schemas/UserResponseData"
+        unfollowed_user:
+          $ref: "#/components/schemas/UserResponseData"
+      required:
+      - current_user
+      - unfollowed_user
+      - users
+      type: object
     DateSpotSummaryData:
       example:
         city_name: city_name
@@ -2096,9 +2869,9 @@ components:
       required:
       - date_spot_id
       type: object
-    DateSpotReviewResponseData:
+    DateSpotShowResponseData:
       example:
-        review_average_rate: 5.637377
+        review_average_rate: 0.8008282
         date_spot:
           city_name: city_name
           prefecture_name: prefecture_name
@@ -2120,34 +2893,34 @@ components:
           genre_name: genre_name
           longitude: 1.4658129
         date_spot_reviews:
-        - rate: 6.0274563
-          user_id: 1
+        - rate: 1.4658129
+          user_id: 5
           user_image:
             url: https://openapi-generator.tech
           user_name: user_name
           date_spot_id: 5
           user_gender: user_gender
-          id: 0
+          id: 6
           content: content
-        - rate: 6.0274563
-          user_id: 1
+        - rate: 1.4658129
+          user_id: 5
           user_image:
             url: https://openapi-generator.tech
           user_name: user_name
           date_spot_id: 5
           user_gender: user_gender
-          id: 0
+          id: 6
           content: content
       properties:
         date_spot:
           $ref: "#/components/schemas/DateSpotSummaryData"
-        date_spot_reviews:
-          items:
-            $ref: "#/components/schemas/DateSpotReviewResponseData_date_spot_reviews_inner"
-          type: array
         review_average_rate:
           format: float
           type: number
+        date_spot_reviews:
+          items:
+            $ref: "#/components/schemas/DateSpotShowResponseData_date_spot_reviews_inner"
+          type: array
       required:
       - date_spot
       - date_spot_reviews
@@ -2169,6 +2942,40 @@ components:
       - date_spot_id
       - rate
       - user_id
+      type: object
+    DateSpotReviewResponseData:
+      example:
+        review_average_rate: 5
+        date_spot_reviews:
+        - rate: 6.0274563
+          user_id: 1
+          user_image:
+            url: https://openapi-generator.tech
+          user_name: user_name
+          date_spot_id: 5
+          user_gender: user_gender
+          id: 0
+          content: content
+        - rate: 6.0274563
+          user_id: 1
+          user_image:
+            url: https://openapi-generator.tech
+          user_name: user_name
+          date_spot_id: 5
+          user_gender: user_gender
+          id: 0
+          content: content
+      properties:
+        date_spot_reviews:
+          items:
+            $ref: "#/components/schemas/DateSpotReviewResponseData_date_spot_reviews_inner"
+          type: array
+        review_average_rate:
+          format: float
+          type: integer
+      required:
+      - date_spot_reviews
+      - review_average_rate
       type: object
     CourseResponseData:
       example:
@@ -2276,9 +3083,9 @@ components:
       type: object
     CourseFormResponseData:
       example:
-        date_spot_id: 0
+        course_id: 0
       properties:
-        date_spot_id:
+        course_id:
           type: integer
       required:
       - course_id
@@ -2331,6 +3138,37 @@ components:
       - 男性
       - 女性
       type: string
+    UserData:
+      example:
+        image:
+          url: https://openapi-generator.tech
+        gender: null
+        name: name
+        admin: true
+        id: 5
+        email: email
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        email:
+          format: email
+          type: string
+        gender:
+          $ref: "#/components/schemas/Gender"
+        image:
+          $ref: "#/components/schemas/ImageData"
+        admin:
+          type: boolean
+      required:
+      - admin
+      - email
+      - gender
+      - id
+      - image
+      - name
+      type: object
     ImageData:
       example:
         url: https://openapi-generator.tech
@@ -2430,47 +3268,65 @@ components:
       required:
       - url
       type: object
-    UserData:
+    _api_v1_genres__id__get_200_response:
       example:
-        image:
-          url: https://openapi-generator.tech
-        gender: null
-        name: name
-        admin: true
-        id: 5
-        email: email
+        address_and_date_spots:
+        - city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
+        - city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
       properties:
-        id:
-          type: integer
-        name:
-          type: string
-        email:
-          format: email
-          type: string
-        gender:
-          $ref: "#/components/schemas/Gender"
-        image:
-          $ref: "#/components/schemas/ImageData"
-        admin:
-          type: boolean
+        address_and_date_spots:
+          items:
+            $ref: "#/components/schemas/DateSpotSummaryData"
+          type: array
       required:
-      - admin
-      - email
-      - gender
-      - id
-      - image
-      - name
+      - address_and_date_spots
       type: object
-    DateSpotReviewResponseData_date_spot_reviews_inner:
+    DateSpotShowResponseData_date_spot_reviews_inner:
       example:
-        rate: 6.0274563
-        user_id: 1
+        rate: 1.4658129
+        user_id: 5
         user_image:
           url: https://openapi-generator.tech
         user_name: user_name
         date_spot_id: 5
         user_gender: user_gender
-        id: 0
+        id: 6
         content: content
       properties:
         id:
@@ -2495,6 +3351,45 @@ components:
       required:
       - date_spot_id
       - id
+      - user_gender
+      - user_id
+      - user_image
+      - user_name
+      type: object
+    DateSpotReviewResponseData_date_spot_reviews_inner:
+      example:
+        rate: 6.0274563
+        user_id: 1
+        user_image:
+          url: https://openapi-generator.tech
+        user_name: user_name
+        date_spot_id: 5
+        user_gender: user_gender
+        id: 0
+        content: content
+      properties:
+        id:
+          type: integer
+        rate:
+          format: float
+          type: number
+        content:
+          type: string
+        user_id:
+          type: integer
+        date_spot_id:
+          type: integer
+        user_name:
+          type: string
+        user_gender:
+          type: string
+        user_image:
+          $ref: "#/components/schemas/ImageData"
+      required:
+      - content
+      - date_spot_id
+      - id
+      - rate
       - user_gender
       - user_id
       - user_image

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -84,7 +84,7 @@ paths:
     post:
       requestBody:
         content:
-          application/x-www-form-urlencoded:
+          application/json:
             schema:
               $ref: "#/components/schemas/SigninFormRequestData"
         required: true
@@ -965,16 +965,23 @@ components:
               genre_id: 9
             id: 2
             content: content
+        token: token
       properties:
         user:
           $ref: "#/components/schemas/UserResponseData"
         login_status:
           type: boolean
+        token:
+          type: string
       required:
       - login_status
+      - token
       - user
       type: object
     SigninFormRequestData:
+      example:
+        password: password
+        name: name
       properties:
         name:
           type: string
@@ -2945,35 +2952,58 @@ components:
       type: object
     DateSpotReviewResponseData:
       example:
-        review_average_rate: 5
+        review_average_rate: 0.8008282
+        date_spot:
+          city_name: city_name
+          prefecture_name: prefecture_name
+          latitude: 6.0274563
+          review_total_number: 5
+          average_rate: 5.637377
+          date_spot:
+            image:
+              url: https://openapi-generator.tech
+            updated_at: 2000-01-23T04:56:07.000+00:00
+            closing_time: 2000-01-23T04:56:07.000+00:00
+            opening_time: 2000-01-23T04:56:07.000+00:00
+            name: name
+            average_rate: 7.0614014
+            created_at: 2000-01-23T04:56:07.000+00:00
+            id: 2
+            genre_id: 9
+          id: 0
+          genre_name: genre_name
+          longitude: 1.4658129
         date_spot_reviews:
-        - rate: 6.0274563
-          user_id: 1
+        - rate: 1.4658129
+          user_id: 5
           user_image:
             url: https://openapi-generator.tech
           user_name: user_name
           date_spot_id: 5
           user_gender: user_gender
-          id: 0
+          id: 6
           content: content
-        - rate: 6.0274563
-          user_id: 1
+        - rate: 1.4658129
+          user_id: 5
           user_image:
             url: https://openapi-generator.tech
           user_name: user_name
           date_spot_id: 5
           user_gender: user_gender
-          id: 0
+          id: 6
           content: content
       properties:
+        date_spot:
+          $ref: "#/components/schemas/DateSpotSummaryData"
         date_spot_reviews:
           items:
-            $ref: "#/components/schemas/DateSpotReviewResponseData_date_spot_reviews_inner"
+            $ref: "#/components/schemas/DateSpotShowResponseData_date_spot_reviews_inner"
           type: array
         review_average_rate:
           format: float
-          type: integer
+          type: number
       required:
+      - date_spot
       - date_spot_reviews
       - review_average_rate
       type: object
@@ -3351,45 +3381,6 @@ components:
       required:
       - date_spot_id
       - id
-      - user_gender
-      - user_id
-      - user_image
-      - user_name
-      type: object
-    DateSpotReviewResponseData_date_spot_reviews_inner:
-      example:
-        rate: 6.0274563
-        user_id: 1
-        user_image:
-          url: https://openapi-generator.tech
-        user_name: user_name
-        date_spot_id: 5
-        user_gender: user_gender
-        id: 0
-        content: content
-      properties:
-        id:
-          type: integer
-        rate:
-          format: float
-          type: number
-        content:
-          type: string
-        user_id:
-          type: integer
-        date_spot_id:
-          type: integer
-        user_name:
-          type: string
-        user_gender:
-          type: string
-        user_image:
-          $ref: "#/components/schemas/ImageData"
-      required:
-      - content
-      - date_spot_id
-      - id
-      - rate
       - user_gender
       - user_id
       - user_image

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -53,7 +53,7 @@ type CourseFormRequestDataTravelMode string
 
 // CourseFormResponseData defines model for CourseFormResponseData.
 type CourseFormResponseData struct {
-	DateSpotId *int `json:"date_spot_id,omitempty"`
+	CourseId int `json:"course_id"`
 }
 
 // CourseResponseData defines model for CourseResponseData.
@@ -113,13 +113,31 @@ type DateSpotReviewFormRequestData struct {
 
 // DateSpotReviewResponseData defines model for DateSpotReviewResponseData.
 type DateSpotReviewResponseData struct {
-	DateSpot          DateSpotSummaryData                              `json:"date_spot"`
 	DateSpotReviews   []DateSpotReviewResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
-	ReviewAverageRate float32                                          `json:"review_average_rate"`
+	ReviewAverageRate int                                              `json:"review_average_rate"`
 }
 
 // DateSpotReviewResponseDataDateSpotReviewsInner defines model for DateSpotReviewResponseData_date_spot_reviews_inner.
 type DateSpotReviewResponseDataDateSpotReviewsInner struct {
+	Content    string    `json:"content"`
+	DateSpotId int       `json:"date_spot_id"`
+	Id         int       `json:"id"`
+	Rate       float32   `json:"rate"`
+	UserGender string    `json:"user_gender"`
+	UserId     int       `json:"user_id"`
+	UserImage  ImageData `json:"user_image"`
+	UserName   string    `json:"user_name"`
+}
+
+// DateSpotShowResponseData defines model for DateSpotShowResponseData.
+type DateSpotShowResponseData struct {
+	DateSpot          DateSpotSummaryData                            `json:"date_spot"`
+	DateSpotReviews   []DateSpotShowResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
+	ReviewAverageRate float32                                        `json:"review_average_rate"`
+}
+
+// DateSpotShowResponseDataDateSpotReviewsInner defines model for DateSpotShowResponseData_date_spot_reviews_inner.
+type DateSpotShowResponseDataDateSpotReviewsInner struct {
 	Content    *string   `json:"content"`
 	DateSpotId int       `json:"date_spot_id"`
 	Id         int       `json:"id"`
@@ -183,8 +201,9 @@ type ImageData1 struct {
 
 // LoginResponseData defines model for LoginResponseData.
 type LoginResponseData struct {
-	LoginStatus bool   `json:"login_status"`
-	Token       string `json:"token"`
+	LoginStatus bool     `json:"login_status"`
+	Token       string   `json:"token"`
+	User        UserData `json:"user"`
 }
 
 // PrefectureData defines model for PrefectureData.
@@ -202,9 +221,8 @@ type RelationShipResponsData struct {
 
 // SignUpResponseData defines model for SignUpResponseData.
 type SignUpResponseData struct {
-	LoginStatus bool        `json:"login_status"`
-	Token       string      `json:"token"`
-	User        interface{} `json:"user"`
+	LoginStatus bool             `json:"login_status"`
+	User        UserResponseData `json:"user"`
 }
 
 // SigninFormRequestData defines model for SigninFormRequestData.
@@ -230,6 +248,13 @@ type TopResponseData struct {
 	Genres          []GenreData           `json:"genres"`
 	MainGenres      []GenreData           `json:"main_genres"`
 	MainPrefectures []PrefectureData      `json:"main_prefectures"`
+}
+
+// UnFollowResponseData defines model for UnFollowResponseData.
+type UnFollowResponseData struct {
+	CurrentUser    UserResponseData   `json:"current_user"`
+	UnfollowedUser UserResponseData   `json:"unfollowed_user"`
+	Users          []UserResponseData `json:"users"`
 }
 
 // UserData defines model for UserData.
@@ -272,6 +297,11 @@ type WelcomeResponseData struct {
 	Message string `json:"message"`
 }
 
+// ApiV1GenresIdGet200Response defines model for _api_v1_genres__id__get_200_response.
+type ApiV1GenresIdGet200Response struct {
+	AddressAndDateSpots []DateSpotSummaryData `json:"address_and_date_spots"`
+}
+
 // GetApiV1CoursesParams defines parameters for GetApiV1Courses.
 type GetApiV1CoursesParams struct {
 	PrefectureId *int `form:"prefecture_id,omitempty" json:"prefecture_id,omitempty"`
@@ -305,8 +335,8 @@ type PostApiV1DateSpotsMultipartRequestBody = DateSpotFormRequestData
 // PutApiV1DateSpotsIdMultipartRequestBody defines body for PutApiV1DateSpotsId for multipart/form-data ContentType.
 type PutApiV1DateSpotsIdMultipartRequestBody = DateSpotFormRequestData
 
-// PostApiV1LoginJSONRequestBody defines body for PostApiV1Login for application/json ContentType.
-type PostApiV1LoginJSONRequestBody = SigninFormRequestData
+// PostApiV1LoginFormdataRequestBody defines body for PostApiV1Login for application/x-www-form-urlencoded ContentType.
+type PostApiV1LoginFormdataRequestBody = SigninFormRequestData
 
 // PostApiV1RelationshipsFormdataRequestBody defines body for PostApiV1Relationships for application/x-www-form-urlencoded ContentType.
 type PostApiV1RelationshipsFormdataRequestBody = FollowReauestData

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -113,20 +113,9 @@ type DateSpotReviewFormRequestData struct {
 
 // DateSpotReviewResponseData defines model for DateSpotReviewResponseData.
 type DateSpotReviewResponseData struct {
-	DateSpotReviews   []DateSpotReviewResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
-	ReviewAverageRate int                                              `json:"review_average_rate"`
-}
-
-// DateSpotReviewResponseDataDateSpotReviewsInner defines model for DateSpotReviewResponseData_date_spot_reviews_inner.
-type DateSpotReviewResponseDataDateSpotReviewsInner struct {
-	Content    string    `json:"content"`
-	DateSpotId int       `json:"date_spot_id"`
-	Id         int       `json:"id"`
-	Rate       float32   `json:"rate"`
-	UserGender string    `json:"user_gender"`
-	UserId     int       `json:"user_id"`
-	UserImage  ImageData `json:"user_image"`
-	UserName   string    `json:"user_name"`
+	DateSpot          DateSpotSummaryData                            `json:"date_spot"`
+	DateSpotReviews   []DateSpotShowResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
+	ReviewAverageRate float32                                        `json:"review_average_rate"`
 }
 
 // DateSpotShowResponseData defines model for DateSpotShowResponseData.
@@ -222,6 +211,7 @@ type RelationShipResponsData struct {
 // SignUpResponseData defines model for SignUpResponseData.
 type SignUpResponseData struct {
 	LoginStatus bool             `json:"login_status"`
+	Token       string           `json:"token"`
 	User        UserResponseData `json:"user"`
 }
 
@@ -335,8 +325,8 @@ type PostApiV1DateSpotsMultipartRequestBody = DateSpotFormRequestData
 // PutApiV1DateSpotsIdMultipartRequestBody defines body for PutApiV1DateSpotsId for multipart/form-data ContentType.
 type PutApiV1DateSpotsIdMultipartRequestBody = DateSpotFormRequestData
 
-// PostApiV1LoginFormdataRequestBody defines body for PostApiV1Login for application/x-www-form-urlencoded ContentType.
-type PostApiV1LoginFormdataRequestBody = SigninFormRequestData
+// PostApiV1LoginJSONRequestBody defines body for PostApiV1Login for application/json ContentType.
+type PostApiV1LoginJSONRequestBody = SigninFormRequestData
 
 // PostApiV1RelationshipsFormdataRequestBody defines body for PostApiV1Relationships for application/x-www-form-urlencoded ContentType.
 type PostApiV1RelationshipsFormdataRequestBody = FollowReauestData

--- a/internal/interface/openapi/login.go
+++ b/internal/interface/openapi/login.go
@@ -1,18 +1,25 @@
 package openapi
 
-import "github.com/daisuke-harada/date-courses-go/internal/domain/model"
+import (
+	openapi_types "github.com/oapi-codegen/runtime/types"
 
-type LoginUserResponseData struct {
-	ID     uint    `json:"id"`
-	Name   string  `json:"name"`
-	Email  string  `json:"email"`
-	Gender Gender  `json:"gender"`
-	Image  *string `json:"image"`
-	Admin  bool    `json:"admin"`
-}
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+)
 
 func NewLoginResponse(user *model.User, token string) (LoginResponseData, error) {
+	gender, err := NewGender(user.Gender)
+	if err != nil {
+		return LoginResponseData{}, err
+	}
 	return LoginResponseData{
+		User: UserData{
+			Id:     int(user.ID),
+			Name:   user.Name,
+			Email:  openapi_types.Email(user.Email),
+			Gender: gender,
+			Admin:  user.Admin,
+			Image:  ImageData{Url: user.Image},
+		},
 		LoginStatus: true,
 		Token:       token,
 	}, nil


### PR DESCRIPTION
## Summary

- `courses_id.yaml`: GET `/courses/:id` の 200 レスポンスを `array` → 単一の `CourseResponseData` に修正
- `courses.yaml`: GET `/courses` の 200 レスポンスを単一 → `CourseResponseData` の配列に修正
- `registration.yaml`: `$reg:` タイポを `$ref:` に修正
- `courses.yaml`: `CourseFormResponseData` のプロパティ名 `date_spot_id` → `course_id` に修正（Rails は `{ course_id: ... }` を返す）
- `genres_id.yaml`: GET `/genres/:id` の 200 レスポンススキーマ（`address_and_date_spots` 配列）を追加（空だった）
- `relationship.yaml`: `UnFollowResponseData` のキー `un_followed_user` → `unfollowed_user` に修正（Rails は `unfollowed_user` を返す）
- `relationships_current_user_id_other_user_id.yaml`: DELETE エンドポイントの参照を `FollowResponseData` → `UnFollowResponseData` に修正
- `session.yaml`: `LoginResponseData` に `user` フィールドを追加
- `date_spot_review.yaml`: `DateSpotShowResponseData` スキーマを新規追加（`date_spot`, `review_average_rate`, `date_spot_reviews` を持つ）
- `date_spots_id.yaml`: GET `/date_spots/:id` を `DateSpotSummaryData` → `DateSpotShowResponseData` 参照に修正
- `get_api_v1_top_test.go`: `main_prefecture` タイポ → `main_prefectures` に修正

## Test plan

- [x] `make gen` 成功
- [x] `go build ./...` ビルドエラーなし
- [x] `go test ./...` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)