### PR TITLE
fix: GET /api/v1/genres/:id のレスポンスキーを date_spots に変更

### DIFF
--- a/api/paths/genres_id.yaml
+++ b/api/paths/genres_id.yaml
@@ -10,9 +10,9 @@ get:
           schema:
             type: object
             required:
-              - address_and_date_spots
+              - date_spots
             properties:
-              address_and_date_spots:
+              date_spots:
                 type: array
                 items:
                   $ref: "../components/schemas/response/date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -3300,7 +3300,7 @@ components:
       type: object
     _api_v1_genres__id__get_200_response:
       example:
-        address_and_date_spots:
+        date_spots:
         - city_name: city_name
           prefecture_name: prefecture_name
           latitude: 6.0274563
@@ -3340,12 +3340,12 @@ components:
           genre_name: genre_name
           longitude: 1.4658129
       properties:
-        address_and_date_spots:
+        date_spots:
           items:
             $ref: "#/components/schemas/DateSpotSummaryData"
           type: array
       required:
-      - address_and_date_spots
+      - date_spots
       type: object
     DateSpotShowResponseData_date_spot_reviews_inner:
       example:

--- a/internal/interface/handler/get_api_v1_genres_id.go
+++ b/internal/interface/handler/get_api_v1_genres_id.go
@@ -21,6 +21,6 @@ func (h *GetApiV1GenresIdHandler) GetApiV1GenresId(ctx echo.Context, arg1 int) e
 		return err
 	}
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"address_and_date_spots": openapi.NewDateSpotsResponse(output.DateSpots),
+		"date_spots": openapi.NewDateSpotsResponse(output.DateSpots),
 	})
 }

--- a/internal/interface/handler/get_api_v1_genres_id_test.go
+++ b/internal/interface/handler/get_api_v1_genres_id_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestGetApiV1GenresIdHandler(t *testing.T) {
-	t.Run("success_returns_200_with_address_and_date_spots", func(t *testing.T) {
+	t.Run("success_returns_200_with_date_spots", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -41,7 +41,7 @@ func TestGetApiV1GenresIdHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "address_and_date_spots")
+		assert.Contains(t, resp, "date_spots")
 	})
 
 	t.Run("error_usecase_returns_internal_server_error", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `api/paths/genres_id.yaml`: レスポンススキーマのキーを `address_and_date_spots` → `date_spots` に変更
- `get_api_v1_genres_id.go`: ハンドラの map キーを `address_and_date_spots` → `date_spots` に変更
- `get_api_v1_genres_id_test.go`: テストのアサーションを `date_spots` に更新

## 関連 PR

- ベースブランチ: #99（OpenAPI スキーマ全体修正）

## Test plan

- [x] `make gen` 成功
- [x] `go build ./...` ビルドエラーなし
- [x] `go test ./...` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)