### PR TITLE
refactor: response整形関数をOpenAPI生成型に統一する

### DIFF
--- a/api/components/schemas/response/date_spot_review.yaml
+++ b/api/components/schemas/response/date_spot_review.yaml
@@ -63,12 +63,9 @@ components:
     DateSpotReviewResponseData:
       type: object
       required:
-        - date_spot
         - date_spot_reviews
         - review_average_rate
       properties:
-        date_spot:
-          $ref: "./date_spot_summary_data.yaml#/components/schemas/DateSpotSummaryData"
         date_spot_reviews:
           type: array
           items:

--- a/api/resolved/openapi/openapi.yaml
+++ b/api/resolved/openapi/openapi.yaml
@@ -2953,26 +2953,6 @@ components:
     DateSpotReviewResponseData:
       example:
         review_average_rate: 0.8008282
-        date_spot:
-          city_name: city_name
-          prefecture_name: prefecture_name
-          latitude: 6.0274563
-          review_total_number: 5
-          average_rate: 5.637377
-          date_spot:
-            image:
-              url: https://openapi-generator.tech
-            updated_at: 2000-01-23T04:56:07.000+00:00
-            closing_time: 2000-01-23T04:56:07.000+00:00
-            opening_time: 2000-01-23T04:56:07.000+00:00
-            name: name
-            average_rate: 7.0614014
-            created_at: 2000-01-23T04:56:07.000+00:00
-            id: 2
-            genre_id: 9
-          id: 0
-          genre_name: genre_name
-          longitude: 1.4658129
         date_spot_reviews:
         - rate: 1.4658129
           user_id: 5
@@ -2993,8 +2973,6 @@ components:
           id: 6
           content: content
       properties:
-        date_spot:
-          $ref: "#/components/schemas/DateSpotSummaryData"
         date_spot_reviews:
           items:
             $ref: "#/components/schemas/DateSpotShowResponseData_date_spot_reviews_inner"
@@ -3003,7 +2981,6 @@ components:
           format: float
           type: number
       required:
-      - date_spot
       - date_spot_reviews
       - review_average_rate
       type: object

--- a/internal/domain/repository/date_spot_review_repository.go
+++ b/internal/domain/repository/date_spot_review_repository.go
@@ -8,6 +8,7 @@ import (
 
 type DateSpotReviewRepository interface {
 	Create(ctx context.Context, review *model.DateSpotReview) error
+	FindByID(ctx context.Context, id uint) (*model.DateSpotReview, error)
 	FindByUserID(ctx context.Context, userID uint) ([]*model.DateSpotReview, error)
 	FindByDateSpotID(ctx context.Context, dateSpotID uint) ([]*model.DateSpotReview, error)
 	DeleteByID(ctx context.Context, id uint) error

--- a/internal/domain/repository/mock/date_spot_review_repository.go
+++ b/internal/domain/repository/mock/date_spot_review_repository.go
@@ -55,21 +55,6 @@ func (mr *MockDateSpotReviewRepositoryMockRecorder) Create(ctx, review any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).Create), ctx, review)
 }
 
-// FindByID mocks base method.
-func (m *MockDateSpotReviewRepository) FindByID(ctx context.Context, id uint) (*model.DateSpotReview, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByID", ctx, id)
-	ret0, _ := ret[0].(*model.DateSpotReview)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FindByID indicates an expected call of FindByID.
-func (mr *MockDateSpotReviewRepositoryMockRecorder) FindByID(ctx, id any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).FindByID), ctx, id)
-}
-
 // DeleteByID mocks base method.
 func (m *MockDateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) error {
 	m.ctrl.T.Helper()
@@ -97,6 +82,21 @@ func (m *MockDateSpotReviewRepository) FindByDateSpotID(ctx context.Context, dat
 func (mr *MockDateSpotReviewRepositoryMockRecorder) FindByDateSpotID(ctx, dateSpotID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByDateSpotID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).FindByDateSpotID), ctx, dateSpotID)
+}
+
+// FindByID mocks base method.
+func (m *MockDateSpotReviewRepository) FindByID(ctx context.Context, id uint) (*model.DateSpotReview, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", ctx, id)
+	ret0, _ := ret[0].(*model.DateSpotReview)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID.
+func (mr *MockDateSpotReviewRepositoryMockRecorder) FindByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).FindByID), ctx, id)
 }
 
 // FindByUserID mocks base method.

--- a/internal/domain/repository/mock/date_spot_review_repository.go
+++ b/internal/domain/repository/mock/date_spot_review_repository.go
@@ -55,6 +55,21 @@ func (mr *MockDateSpotReviewRepositoryMockRecorder) Create(ctx, review any) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).Create), ctx, review)
 }
 
+// FindByID mocks base method.
+func (m *MockDateSpotReviewRepository) FindByID(ctx context.Context, id uint) (*model.DateSpotReview, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", ctx, id)
+	ret0, _ := ret[0].(*model.DateSpotReview)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID.
+func (mr *MockDateSpotReviewRepositoryMockRecorder) FindByID(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockDateSpotReviewRepository)(nil).FindByID), ctx, id)
+}
+
 // DeleteByID mocks base method.
 func (m *MockDateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) error {
 	m.ctrl.T.Helper()

--- a/internal/infrastructure/persistence/date_spot_review_repository.go
+++ b/internal/infrastructure/persistence/date_spot_review_repository.go
@@ -26,6 +26,16 @@ func (r *dateSpotReviewRepository) Create(ctx context.Context, review *model.Dat
 	return nil
 }
 
+// FindByID は指定 ID のレビューを返します。
+func (r *dateSpotReviewRepository) FindByID(ctx context.Context, id uint) (*model.DateSpotReview, error) {
+	var review model.DateSpotReview
+	if err := r.db.WithContext(ctx).First(&review, id).Error; err != nil {
+		slog.ErrorContext(ctx, "dateSpotReviewRepository.FindByID failed", "err", err)
+		return nil, err
+	}
+	return &review, nil
+}
+
 // DeleteByID は指定 ID のレビューを削除します。
 func (r *dateSpotReviewRepository) DeleteByID(ctx context.Context, id uint) error {
 	if err := r.db.WithContext(ctx).Delete(&model.DateSpotReview{}, id).Error; err != nil {

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -12,11 +13,12 @@ type DeleteApiV1DateSpotReviewsIdHandler struct {
 }
 
 func (h *DeleteApiV1DateSpotReviewsIdHandler) DeleteApiV1DateSpotReviewsId(ctx echo.Context, arg1 int) error {
-	err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteDateSpotReviewInput{
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteDateSpotReviewInput{
 		ReviewID: uint(arg1),
 	})
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
 }

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id.go
@@ -20,5 +20,5 @@ func (h *DeleteApiV1DateSpotReviewsIdHandler) DeleteApiV1DateSpotReviewsId(ctx e
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotReviewResponse(output.DateSpotReviews))
 }

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
@@ -1,12 +1,14 @@
 package handler_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
@@ -16,14 +18,17 @@ import (
 )
 
 func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
-	t.Run("success_returns_200", func(t *testing.T) {
+	t.Run("success_returns_200_with_date_spot", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockDeleteDateSpotReviewInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), usecase.DeleteDateSpotReviewInput{ReviewID: 10}).
-			Return(nil)
+			Return(&usecase.DeleteDateSpotReviewOutput{
+				DateSpot:        &model.DateSpot{ID: 5, Name: "テストスポット"},
+				DateSpotReviews: []*model.DateSpotReview{},
+			}, nil)
 
 		ctx, rec := setupFormRequest(http.MethodDelete, "/api/v1/date_spot_reviews/10", url.Values{})
 
@@ -32,6 +37,12 @@ func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Contains(t, resp, "date_spot")
+		assert.Contains(t, resp, "date_spot_reviews")
+		assert.Contains(t, resp, "review_average_rate")
 	})
 
 	t.Run("error_usecase_returns_error", func(t *testing.T) {
@@ -41,7 +52,7 @@ func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
 		mockPort := usecasemock.NewMockDeleteDateSpotReviewInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), gomock.Any()).
-			Return(apperror.InternalServerError(errors.New("db error")))
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
 
 		ctx, _ := setupFormRequest(http.MethodDelete, "/api/v1/date_spot_reviews/10", url.Values{})
 

--- a/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
+++ b/internal/interface/handler/delete_api_v1_date_spot_reviews_id_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
-	t.Run("success_returns_200_with_date_spot", func(t *testing.T) {
+	t.Run("success_returns_200_with_reviews", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -26,7 +26,6 @@ func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
 		mockPort.EXPECT().
 			Execute(gomock.Any(), usecase.DeleteDateSpotReviewInput{ReviewID: 10}).
 			Return(&usecase.DeleteDateSpotReviewOutput{
-				DateSpot:        &model.DateSpot{ID: 5, Name: "テストスポット"},
 				DateSpotReviews: []*model.DateSpotReview{},
 			}, nil)
 
@@ -40,7 +39,6 @@ func TestDeleteApiV1DateSpotReviewsIdHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "date_spot")
 		assert.Contains(t, resp, "date_spot_reviews")
 		assert.Contains(t, resp, "review_average_rate")
 	})

--- a/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
+++ b/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -12,12 +14,18 @@ type DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler struct {
 }
 
 func (h *DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler) DeleteApiV1RelationshipsCurrentUserIdOtherUserId(ctx echo.Context, arg1 int, arg2 int) error {
-	err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteRelationshipInput{
+	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.DeleteRelationshipInput{
 		UserID:   uint(arg1),
 		FollowID: uint(arg2),
 	})
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+
+	resp, err := openapi.BuildDeleteRelationshipResponse(output)
+	if err != nil {
+		return apperror.InternalServerError(err)
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
 }

--- a/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
+++ b/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id.go
@@ -22,7 +22,7 @@ func (h *DeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler) DeleteApiV1Rel
 		return err
 	}
 
-	resp, err := openapi.BuildDeleteRelationshipResponse(output)
+	resp, err := openapi.NewUnFollowResponseData(output)
 	if err != nil {
 		return apperror.InternalServerError(err)
 	}

--- a/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id_test.go
+++ b/internal/interface/handler/delete_api_v1_relationships_current_user_id_other_user_id_test.go
@@ -1,12 +1,14 @@
 package handler_test
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
@@ -16,14 +18,29 @@ import (
 )
 
 func TestDeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler(t *testing.T) {
-	t.Run("success_returns_200", func(t *testing.T) {
+	t.Run("success_returns_200_with_users", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
+
+		currentUwr := &model.UserWithRelations{
+			User:         &model.User{ID: 1, Name: "current", Email: "current@example.com", Gender: "男性"},
+			FollowerIDs:  []int{},
+			FollowingIDs: []int{},
+		}
+		unfollowedUwr := &model.UserWithRelations{
+			User:         &model.User{ID: 2, Name: "unfollowed", Email: "unfollowed@example.com", Gender: "女性"},
+			FollowerIDs:  []int{},
+			FollowingIDs: []int{},
+		}
 
 		mockPort := usecasemock.NewMockDeleteRelationshipInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), usecase.DeleteRelationshipInput{UserID: 1, FollowID: 2}).
-			Return(nil)
+			Return(&usecase.DeleteRelationshipOutput{
+				Users:          []*model.UserWithRelations{currentUwr, unfollowedUwr},
+				CurrentUser:    currentUwr,
+				UnfollowedUser: unfollowedUwr,
+			}, nil)
 
 		ctx, rec := setupFormRequest(http.MethodDelete, "/api/v1/relationships/1/2", url.Values{})
 
@@ -32,6 +49,12 @@ func TestDeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.Contains(t, resp, "users")
+		assert.Contains(t, resp, "current_user")
+		assert.Contains(t, resp, "unfollowed_user")
 	})
 
 	t.Run("error_usecase_returns_error", func(t *testing.T) {
@@ -41,7 +64,7 @@ func TestDeleteApiV1RelationshipsCurrentUserIdOtherUserIdHandler(t *testing.T) {
 		mockPort := usecasemock.NewMockDeleteRelationshipInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), gomock.Any()).
-			Return(apperror.InternalServerError(errors.New("db error")))
+			Return(nil, apperror.InternalServerError(errors.New("db error")))
 
 		ctx, _ := setupFormRequest(http.MethodDelete, "/api/v1/relationships/1/2", url.Values{})
 

--- a/internal/interface/handler/get_api_v1_courses.go
+++ b/internal/interface/handler/get_api_v1_courses.go
@@ -22,7 +22,7 @@ func (h *GetApiV1CoursesHandler) GetApiV1Courses(ctx echo.Context, params openap
 		return err
 	}
 
-	resp, err := openapi.BuildGetCoursesResponse(output)
+	resp, err := openapi.NewCoursesResponse(output.Courses)
 	if err != nil {
 		return apperror.InternalServerError(err)
 	}

--- a/internal/interface/handler/get_api_v1_courses_id.go
+++ b/internal/interface/handler/get_api_v1_courses_id.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"net/http"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -16,13 +18,11 @@ func (h *GetApiV1CoursesIdHandler) GetApiV1CoursesId(ctx echo.Context, arg1 int)
 	if err != nil {
 		return err
 	}
-	course := output.Course
-	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"id":          course.ID,
-		"user_id":     course.UserID,
-		"travel_mode": course.TravelMode,
-		"authority":   course.Authority,
-		"created_at":  course.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		"updated_at":  course.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
-	})
+
+	resp, err := openapi.NewCourseResponse(output.Course)
+	if err != nil {
+		return apperror.InternalServerError(err)
+	}
+
+	return ctx.JSON(http.StatusOK, resp)
 }

--- a/internal/interface/handler/get_api_v1_courses_id_test.go
+++ b/internal/interface/handler/get_api_v1_courses_id_test.go
@@ -29,9 +29,9 @@ func TestGetApiV1CoursesIdHandler(t *testing.T) {
 			Return(&usecase.GetCourseOutput{
 				Course: &model.Course{
 					ID:         1,
-					UserID:     2,
 					TravelMode: "DRIVING",
 					Authority:  "公開",
+					User:       newTestUser(2, "user@example.com"),
 				},
 			}, nil)
 
@@ -49,9 +49,10 @@ func TestGetApiV1CoursesIdHandler(t *testing.T) {
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 		assert.Equal(t, float64(1), resp["id"])
-		assert.Equal(t, float64(2), resp["user_id"])
 		assert.Equal(t, "DRIVING", resp["travel_mode"])
 		assert.Equal(t, "公開", resp["authority"])
+		user := resp["user"].(map[string]interface{})
+		assert.Equal(t, float64(2), user["id"])
 	})
 
 	t.Run("error_not_found", func(t *testing.T) {

--- a/internal/interface/handler/get_api_v1_courses_test.go
+++ b/internal/interface/handler/get_api_v1_courses_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
@@ -19,15 +18,23 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func newTestUser(id uint, email string) *model.User {
+	return &model.User{
+		ID:     id,
+		Name:   "テストユーザー",
+		Email:  email,
+		Gender: model.GenderMale,
+	}
+}
+
 func TestGetApiV1CoursesHandler(t *testing.T) {
 	t.Run("success_returns_200_with_courses", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		now := time.Now()
 		courses := []*model.Course{
-			{ID: 1, UserID: 1, TravelMode: "car", Authority: "public", CreatedAt: now, UpdatedAt: now},
-			{ID: 2, UserID: 2, TravelMode: "walk", Authority: "public", CreatedAt: now, UpdatedAt: now},
+			{ID: 1, TravelMode: "car", Authority: "public", User: newTestUser(1, "user1@example.com")},
+			{ID: 2, TravelMode: "walk", Authority: "public", User: newTestUser(2, "user2@example.com")},
 		}
 
 		mockPort := usecasemock.NewMockGetCoursesInputPort(ctrl)
@@ -46,21 +53,18 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
-		var resp map[string]interface{}
+		var resp []interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "courses")
-		coursesList := resp["courses"].([]interface{})
-		assert.Equal(t, 2, len(coursesList))
+		assert.Equal(t, 2, len(resp))
 	})
 
 	t.Run("success_with_prefecture_id_filter", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		now := time.Now()
 		prefectureID := 13
 		courses := []*model.Course{
-			{ID: 1, UserID: 1, TravelMode: "car", Authority: "public", CreatedAt: now, UpdatedAt: now},
+			{ID: 1, TravelMode: "car", Authority: "public", User: newTestUser(1, "user1@example.com")},
 		}
 
 		mockPort := usecasemock.NewMockGetCoursesInputPort(ctrl)
@@ -79,10 +83,9 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
-		var resp map[string]interface{}
+		var resp []interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		coursesList := resp["courses"].([]interface{})
-		assert.Equal(t, 1, len(coursesList))
+		assert.Equal(t, 1, len(resp))
 	})
 
 	t.Run("success_returns_empty_list", func(t *testing.T) {
@@ -105,10 +108,9 @@ func TestGetApiV1CoursesHandler(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, rec.Code)
 
-		var resp map[string]interface{}
+		var resp []interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		coursesList := resp["courses"].([]interface{})
-		assert.Equal(t, 0, len(coursesList))
+		assert.Equal(t, 0, len(resp))
 	})
 
 	t.Run("error_usecase_failure_returns_error", func(t *testing.T) {

--- a/internal/interface/handler/get_api_v1_genres_id.go
+++ b/internal/interface/handler/get_api_v1_genres_id.go
@@ -20,7 +20,7 @@ func (h *GetApiV1GenresIdHandler) GetApiV1GenresId(ctx echo.Context, arg1 int) e
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"date_spots": openapi.NewDateSpotsResponse(output.DateSpots),
+	return ctx.JSON(http.StatusOK, openapi.ApiV1GenresIdGet200Response{
+		DateSpots: openapi.NewDateSpotSummaries(output.DateSpots),
 	})
 }

--- a/internal/interface/handler/post_api_v1_courses.go
+++ b/internal/interface/handler/post_api_v1_courses.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -43,5 +44,5 @@ func (h *PostApiV1CoursesHandler) PostApiV1Courses(ctx echo.Context) error {
 		return err
 	}
 
-	return ctx.JSON(http.StatusCreated, map[string]int{"course_id": int(output.CourseID)})
+	return ctx.JSON(http.StatusCreated, openapi.NewCreateCourseResponse(output.CourseID))
 }

--- a/internal/interface/handler/post_api_v1_date_spot_reviews.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -53,7 +54,5 @@ func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Cont
 		return err
 	}
 
-	return ctx.JSON(http.StatusCreated, map[string]interface{}{
-		"review_id": int(output.ReviewID),
-	})
+	return ctx.JSON(http.StatusCreated, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
 }

--- a/internal/interface/handler/post_api_v1_date_spot_reviews.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews.go
@@ -2,9 +2,7 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 
-	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
@@ -15,39 +13,14 @@ type PostApiV1DateSpotReviewsHandler struct {
 }
 
 func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Context) error {
-	// user_id: 型変換のみ。バリデーションは usecase.CreateDateSpotReviewInput.Validate() が担う
-	userID, err := strconv.Atoi(ctx.FormValue("user_id"))
+	input, err := usecase.NewCreateDateSpotReviewInputFromStrings(
+		ctx.FormValue("user_id"),
+		ctx.FormValue("date_spot_id"),
+		ctx.FormValue("rate"),
+		ctx.FormValue("content"),
+	)
 	if err != nil {
-		return apperror.BadRequest("user_id は整数で指定してください")
-	}
-
-	// date_spot_id: 型変換のみ
-	dateSpotID, err := strconv.Atoi(ctx.FormValue("date_spot_id"))
-	if err != nil {
-		return apperror.BadRequest("date_spot_id は整数で指定してください")
-	}
-
-	// rate (optional)
-	var rate *float64
-	if rateStr := ctx.FormValue("rate"); rateStr != "" {
-		r, err := strconv.ParseFloat(rateStr, 64)
-		if err != nil {
-			return apperror.BadRequest("rate は数値で指定してください")
-		}
-		rate = &r
-	}
-
-	// content (optional)
-	var content *string
-	if c := ctx.FormValue("content"); c != "" {
-		content = &c
-	}
-
-	input := usecase.CreateDateSpotReviewInput{
-		UserID:     uint(userID),
-		DateSpotID: uint(dateSpotID),
-		Rate:       rate,
-		Content:    content,
+		return err
 	}
 	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
 	if err != nil {
@@ -56,3 +29,5 @@ func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Cont
 
 	return ctx.JSON(http.StatusCreated, openapi.NewDateSpotReviewResponse(output.DateSpotReviews))
 }
+
+// handler defers parsing to usecase.NewCreateDateSpotReviewInputFromStrings

--- a/internal/interface/handler/post_api_v1_date_spot_reviews.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews.go
@@ -54,5 +54,5 @@ func (h *PostApiV1DateSpotReviewsHandler) PostApiV1DateSpotReviews(ctx echo.Cont
 		return err
 	}
 
-	return ctx.JSON(http.StatusCreated, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
+	return ctx.JSON(http.StatusCreated, openapi.NewDateSpotReviewResponse(output.DateSpotReviews))
 }

--- a/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
@@ -27,7 +27,7 @@ func validDateSpotReviewForm() url.Values {
 }
 
 func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
-	t.Run("success_returns_201_with_date_spot", func(t *testing.T) {
+	t.Run("success_returns_201_with_reviews", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -36,7 +36,6 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 			Execute(gomock.Any(), gomock.Any()).
 			Return(&usecase.CreateDateSpotReviewOutput{
 				ReviewID:        10,
-				DateSpot:        &model.DateSpot{ID: 2, Name: "テストスポット"},
 				DateSpotReviews: []*model.DateSpotReview{},
 			}, nil)
 
@@ -50,12 +49,10 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "date_spot")
 		assert.Contains(t, resp, "date_spot_reviews")
 		assert.Contains(t, resp, "review_average_rate")
 	})
 
-	// user_id が空文字（フォーム未送信）は型変換失敗 → handler が BadRequest を返す
 	t.Run("error_bad_request_invalid_user_id", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()

--- a/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
+++ b/internal/interface/handler/post_api_v1_date_spot_reviews_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
@@ -26,14 +27,18 @@ func validDateSpotReviewForm() url.Values {
 }
 
 func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
-	t.Run("success_returns_201_with_review_id", func(t *testing.T) {
+	t.Run("success_returns_201_with_date_spot", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), gomock.Any()).
-			Return(&usecase.CreateDateSpotReviewOutput{ReviewID: 10}, nil)
+			Return(&usecase.CreateDateSpotReviewOutput{
+				ReviewID:        10,
+				DateSpot:        &model.DateSpot{ID: 2, Name: "テストスポット"},
+				DateSpotReviews: []*model.DateSpotReview{},
+			}, nil)
 
 		ctx, rec := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", validDateSpotReviewForm())
 
@@ -45,7 +50,9 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, float64(10), resp["review_id"])
+		assert.Contains(t, resp, "date_spot")
+		assert.Contains(t, resp, "date_spot_reviews")
+		assert.Contains(t, resp, "review_average_rate")
 	})
 
 	// user_id が空文字（フォーム未送信）は型変換失敗 → handler が BadRequest を返す
@@ -54,10 +61,9 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
-		// usecase は呼ばれない
 
 		form := validDateSpotReviewForm()
-		form.Set("user_id", "abc") // 非数値
+		form.Set("user_id", "abc")
 		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
 
 		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
@@ -69,16 +75,14 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, statusCode)
 	})
 
-	// date_spot_id が非数値は型変換失敗 → handler が BadRequest を返す
 	t.Run("error_bad_request_invalid_date_spot_id", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockCreateDateSpotReviewInputPort(ctrl)
-		// usecase は呼ばれない
 
 		form := validDateSpotReviewForm()
-		form.Set("date_spot_id", "xyz") // 非数値
+		form.Set("date_spot_id", "xyz")
 		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)
 
 		h := handler.PostApiV1DateSpotReviewsHandler{InputPort: mockPort}
@@ -90,7 +94,6 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, statusCode)
 	})
 
-	// usecase が UnprocessableEntity を返すケース（Validate() 失敗など）
 	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -100,7 +103,6 @@ func TestPostApiV1DateSpotReviewsHandler(t *testing.T) {
 			Execute(gomock.Any(), gomock.Any()).
 			Return(nil, apperror.UnprocessableEntity("ユーザーIDを入力してください"))
 
-		// user_id=0 → 型変換は成功 → usecase が Validate() で失敗
 		form := validDateSpotReviewForm()
 		form.Set("user_id", "0")
 		ctx, _ := setupFormRequest(http.MethodPost, "/api/v1/date_spot_reviews", form)

--- a/internal/interface/handler/post_api_v1_relationships.go
+++ b/internal/interface/handler/post_api_v1_relationships.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
@@ -15,25 +14,16 @@ type PostApiV1RelationshipsHandler struct {
 }
 
 func (h *PostApiV1RelationshipsHandler) PostApiV1Relationships(ctx echo.Context) error {
-	currentUserID, err := strconv.Atoi(ctx.FormValue("current_user_id"))
+	input, err := usecase.NewCreateRelationshipInputFromStrings(ctx.FormValue("current_user_id"), ctx.FormValue("followed_user_id"))
 	if err != nil {
-		return apperror.BadRequest("current_user_id は数値で指定してください")
+		return err
 	}
-
-	followedUserID, err := strconv.Atoi(ctx.FormValue("followed_user_id"))
-	if err != nil {
-		return apperror.BadRequest("followed_user_id は数値で指定してください")
-	}
-
-	output, err := h.InputPort.Execute(ctx.Request().Context(), usecase.CreateRelationshipInput{
-		CurrentUserID:  uint(currentUserID),
-		FollowedUserID: uint(followedUserID),
-	})
+	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
 	if err != nil {
 		return err
 	}
 
-	resp, err := openapi.BuildCreateRelationshipResponse(output)
+	resp, err := openapi.NewFollowResponseData(output)
 	if err != nil {
 		return apperror.InternalServerError(err)
 	}

--- a/internal/interface/handler/post_api_v1_signup.go
+++ b/internal/interface/handler/post_api_v1_signup.go
@@ -16,17 +16,17 @@ type PostApiV1SignupHandler struct {
 
 func (h *PostApiV1SignupHandler) PostApiV1Signup(ctx echo.Context) error {
 	// multipart/form-data からフィールドを取得
-	gender, err := NewModelGender(ctx.FormValue("gender"))
-	if err != nil {
-		gender = ""
-	}
 
-	input := usecase.SignupInput{
-		Name:                 ctx.FormValue("name"),
-		Email:                ctx.FormValue("email"),
-		Gender:               gender,
-		Password:             ctx.FormValue("password"),
-		PasswordConfirmation: ctx.FormValue("password_confirmation"),
+	input, err := usecase.NewSignupInput(
+		ctx.FormValue("name"),
+		ctx.FormValue("email"),
+		ctx.FormValue("gender"),
+		ctx.FormValue("password"),
+		ctx.FormValue("password_confirmation"),
+		ctx.FormValue("image"),
+	)
+	if err != nil {
+		return err
 	}
 
 	// image は任意フィールド

--- a/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -39,7 +40,6 @@ func (h *PutApiV1DateSpotReviewsIdHandler) PutApiV1DateSpotReviewsId(ctx echo.Co
 	if err != nil {
 		return err
 	}
-	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"review_id": int(output.ReviewID),
-	})
+
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
 }

--- a/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
@@ -15,7 +15,11 @@ type PutApiV1DateSpotReviewsIdHandler struct {
 }
 
 func (h *PutApiV1DateSpotReviewsIdHandler) PutApiV1DateSpotReviewsId(ctx echo.Context, reviewID int) error {
-	// rate (optional): 型変換のみ。バリデーションは usecase.UpdateDateSpotReviewInput.Validate() が担う
+	dateSpotID, err := strconv.Atoi(ctx.FormValue("date_spot_id"))
+	if err != nil {
+		return apperror.BadRequest("date_spot_id は整数で指定してください")
+	}
+
 	var rate *float64
 	if rateStr := ctx.FormValue("rate"); rateStr != "" {
 		r, err := strconv.ParseFloat(rateStr, 64)
@@ -25,21 +29,21 @@ func (h *PutApiV1DateSpotReviewsIdHandler) PutApiV1DateSpotReviewsId(ctx echo.Co
 		rate = &r
 	}
 
-	// content (optional)
 	var content *string
 	if c := ctx.FormValue("content"); c != "" {
 		content = &c
 	}
 
 	input := usecase.UpdateDateSpotReviewInput{
-		ReviewID: uint(reviewID),
-		Rate:     rate,
-		Content:  content,
+		ReviewID:   uint(reviewID),
+		DateSpotID: uint(dateSpotID),
+		Rate:       rate,
+		Content:    content,
 	}
 	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
 	if err != nil {
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, openapi.NewDateSpotShowResponse(output.DateSpot, output.DateSpotReviews))
+	return ctx.JSON(http.StatusOK, openapi.NewDateSpotReviewResponse(output.DateSpotReviews))
 }

--- a/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
+++ b/internal/interface/handler/put_api_v1_date_spot_reviews_id.go
@@ -2,9 +2,7 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 
-	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
@@ -15,30 +13,14 @@ type PutApiV1DateSpotReviewsIdHandler struct {
 }
 
 func (h *PutApiV1DateSpotReviewsIdHandler) PutApiV1DateSpotReviewsId(ctx echo.Context, reviewID int) error {
-	dateSpotID, err := strconv.Atoi(ctx.FormValue("date_spot_id"))
+	input, err := usecase.NewUpdateDateSpotReviewInput(
+		reviewID,
+		ctx.FormValue("date_spot_id"),
+		ctx.FormValue("rate"),
+		ctx.FormValue("content"),
+	)
 	if err != nil {
-		return apperror.BadRequest("date_spot_id は整数で指定してください")
-	}
-
-	var rate *float64
-	if rateStr := ctx.FormValue("rate"); rateStr != "" {
-		r, err := strconv.ParseFloat(rateStr, 64)
-		if err != nil {
-			return apperror.BadRequest("rate は数値で指定してください")
-		}
-		rate = &r
-	}
-
-	var content *string
-	if c := ctx.FormValue("content"); c != "" {
-		content = &c
-	}
-
-	input := usecase.UpdateDateSpotReviewInput{
-		ReviewID:   uint(reviewID),
-		DateSpotID: uint(dateSpotID),
-		Rate:       rate,
-		Content:    content,
+		return err
 	}
 	output, err := h.InputPort.Execute(ctx.Request().Context(), input)
 	if err != nil {

--- a/internal/interface/handler/put_api_v1_date_spot_reviews_id_test.go
+++ b/internal/interface/handler/put_api_v1_date_spot_reviews_id_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/interface/handler"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	usecasemock "github.com/daisuke-harada/date-courses-go/internal/usecase/mock"
@@ -17,14 +18,18 @@ import (
 )
 
 func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
-	t.Run("success_returns_200_with_review_id", func(t *testing.T) {
+	t.Run("success_returns_200_with_date_spot", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockUpdateDateSpotReviewInputPort(ctrl)
 		mockPort.EXPECT().
 			Execute(gomock.Any(), gomock.Any()).
-			Return(&usecase.UpdateDateSpotReviewOutput{ReviewID: 1}, nil)
+			Return(&usecase.UpdateDateSpotReviewOutput{
+				ReviewID:        1,
+				DateSpot:        &model.DateSpot{ID: 3, Name: "テストスポット"},
+				DateSpotReviews: []*model.DateSpotReview{},
+			}, nil)
 
 		form := url.Values{}
 		form.Set("rate", "4.5")
@@ -39,16 +44,16 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Equal(t, float64(1), resp["review_id"])
+		assert.Contains(t, resp, "date_spot")
+		assert.Contains(t, resp, "date_spot_reviews")
+		assert.Contains(t, resp, "review_average_rate")
 	})
 
-	// rate が非数値の場合は型変換失敗 → handler が BadRequest を返す
 	t.Run("error_bad_request_invalid_rate", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		mockPort := usecasemock.NewMockUpdateDateSpotReviewInputPort(ctrl)
-		// usecase は呼ばれない
 
 		form := url.Values{}
 		form.Set("rate", "not-a-number")
@@ -63,7 +68,6 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, statusCode)
 	})
 
-	// rate も content も未指定 → usecase の Validate() が UnprocessableEntity を返す
 	t.Run("error_usecase_returns_unprocessable_entity", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -73,7 +77,7 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 			Execute(gomock.Any(), gomock.Any()).
 			Return(nil, apperror.UnprocessableEntity("rate または content のいずれかを入力してください"))
 
-		form := url.Values{} // rate も content も空
+		form := url.Values{}
 		ctx, _ := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
 
 		h := handler.PutApiV1DateSpotReviewsIdHandler{InputPort: mockPort}

--- a/internal/interface/handler/put_api_v1_date_spot_reviews_id_test.go
+++ b/internal/interface/handler/put_api_v1_date_spot_reviews_id_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
-	t.Run("success_returns_200_with_date_spot", func(t *testing.T) {
+	t.Run("success_returns_200_with_reviews", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -27,11 +27,11 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 			Execute(gomock.Any(), gomock.Any()).
 			Return(&usecase.UpdateDateSpotReviewOutput{
 				ReviewID:        1,
-				DateSpot:        &model.DateSpot{ID: 3, Name: "テストスポット"},
 				DateSpotReviews: []*model.DateSpotReview{},
 			}, nil)
 
 		form := url.Values{}
+		form.Set("date_spot_id", "3")
 		form.Set("rate", "4.5")
 		form.Set("content", "良かった")
 		ctx, rec := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
@@ -44,9 +44,27 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 
 		var resp map[string]interface{}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-		assert.Contains(t, resp, "date_spot")
 		assert.Contains(t, resp, "date_spot_reviews")
 		assert.Contains(t, resp, "review_average_rate")
+	})
+
+	t.Run("error_bad_request_missing_date_spot_id", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockPort := usecasemock.NewMockUpdateDateSpotReviewInputPort(ctrl)
+
+		form := url.Values{}
+		form.Set("rate", "4.5")
+		ctx, _ := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
+
+		h := handler.PutApiV1DateSpotReviewsIdHandler{InputPort: mockPort}
+		err := h.PutApiV1DateSpotReviewsId(ctx, 1)
+
+		assert.Error(t, err)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
 	})
 
 	t.Run("error_bad_request_invalid_rate", func(t *testing.T) {
@@ -56,6 +74,7 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 		mockPort := usecasemock.NewMockUpdateDateSpotReviewInputPort(ctrl)
 
 		form := url.Values{}
+		form.Set("date_spot_id", "3")
 		form.Set("rate", "not-a-number")
 		ctx, _ := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
 
@@ -78,6 +97,7 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 			Return(nil, apperror.UnprocessableEntity("rate または content のいずれかを入力してください"))
 
 		form := url.Values{}
+		form.Set("date_spot_id", "3")
 		ctx, _ := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
 
 		h := handler.PutApiV1DateSpotReviewsIdHandler{InputPort: mockPort}
@@ -99,6 +119,7 @@ func TestPutApiV1DateSpotReviewsIdHandler(t *testing.T) {
 			Return(nil, apperror.InternalServerError(errors.New("db error")))
 
 		form := url.Values{}
+		form.Set("date_spot_id", "3")
 		form.Set("rate", "4.5")
 		ctx, _ := setupFormRequest(http.MethodPut, "/api/v1/date_spot_reviews/1", form)
 

--- a/internal/interface/handler/put_api_v1_date_spots_id.go
+++ b/internal/interface/handler/put_api_v1_date_spots_id.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/daisuke-harada/date-courses-go/internal/interface/openapi"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/labstack/echo/v4"
 )
@@ -47,5 +48,5 @@ func (h *PutApiV1DateSpotsIdHandler) PutApiV1DateSpotsId(ctx echo.Context, id in
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, map[string]string{"message": "success"})
+	return ctx.JSON(http.StatusOK, openapi.DateSpotFormResponseData{DateSpotId: id})
 }

--- a/internal/interface/handler/put_api_v1_date_spots_id.go
+++ b/internal/interface/handler/put_api_v1_date_spots_id.go
@@ -40,10 +40,6 @@ func (h *PutApiV1DateSpotsIdHandler) PutApiV1DateSpotsId(ctx echo.Context, id in
 		Image:        req.Image,
 	}
 
-	if err := input.Validate(); err != nil {
-		return err
-	}
-
 	if err := h.InputPort.Execute(ctx.Request().Context(), input); err != nil {
 		return err
 	}

--- a/internal/interface/handler/put_api_v1_users_id.go
+++ b/internal/interface/handler/put_api_v1_users_id.go
@@ -15,23 +15,17 @@ type PutApiV1UsersIdHandler struct {
 
 func (h *PutApiV1UsersIdHandler) PutApiV1UsersId(ctx echo.Context, id int) error {
 	// multipart/form-data からフィールドを取得
-	gender, err := NewModelGender(ctx.FormValue("gender"))
+	input, err := usecase.NewUpdateUserInput(
+		id,
+		ctx.FormValue("name"),
+		ctx.FormValue("email"),
+		ctx.FormValue("gender"),
+		ctx.FormValue("password"),
+		ctx.FormValue("password_confirmation"),
+		ctx.FormValue("image"),
+	)
 	if err != nil {
-		gender = ""
-	}
-
-	input := usecase.UpdateUserInput{
-		ID:                   uint(id),
-		Name:                 ctx.FormValue("name"),
-		Email:                ctx.FormValue("email"),
-		Gender:               gender,
-		Password:             ctx.FormValue("password"),
-		PasswordConfirmation: ctx.FormValue("password_confirmation"),
-	}
-
-	// image は任意フィールド
-	if image := ctx.FormValue("image"); image != "" {
-		input.Image = &image
+		return err
 	}
 
 	output, err := h.InputPort.Execute(ctx.Request().Context(), input)

--- a/internal/interface/openapi/CLAUDE.md
+++ b/internal/interface/openapi/CLAUDE.md
@@ -15,8 +15,8 @@
 
 ```go
 // internal/interface/openapi/date_spot.go
-func NewDateSpotResponse(ds *model.DateSpot) (DateSpotResponseBody, error) {
-    return DateSpotResponseBody{
+func NewDateSpotResponse(ds *model.DateSpot) (DateSpotResponseData, error) {
+    return DateSpotResponseData{
         Id:   int(ds.ID),
         Name: ds.Name,
         // ...

--- a/internal/interface/openapi/api_types.gen.go
+++ b/internal/interface/openapi/api_types.gen.go
@@ -113,7 +113,6 @@ type DateSpotReviewFormRequestData struct {
 
 // DateSpotReviewResponseData defines model for DateSpotReviewResponseData.
 type DateSpotReviewResponseData struct {
-	DateSpot          DateSpotSummaryData                            `json:"date_spot"`
 	DateSpotReviews   []DateSpotShowResponseDataDateSpotReviewsInner `json:"date_spot_reviews"`
 	ReviewAverageRate float32                                        `json:"review_average_rate"`
 }

--- a/internal/interface/openapi/courses.go
+++ b/internal/interface/openapi/courses.go
@@ -1,22 +1,28 @@
 package openapi
 
 import (
-	"github.com/daisuke-harada/date-courses-go/internal/usecase"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 )
 
-func BuildGetCoursesResponse(output *usecase.GetCoursesOutput) (map[string]interface{}, error) {
-	courses := make([]map[string]interface{}, len(output.Courses))
-	for i, course := range output.Courses {
-		courses[i] = map[string]interface{}{
-			"id":            course.ID,
-			"user_id":       course.UserID,
-			"travel_mode":   course.TravelMode,
-			"authority":     course.Authority,
-			"created_at":    course.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-			"updated_at":    course.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+// NewCoursesResponse は []*model.Course から []CourseResponseDataBody を構築します。
+func NewCoursesResponse(courses []*model.Course) ([]CourseResponseDataBody, error) {
+	responses := make([]CourseResponseDataBody, 0, len(courses))
+	for _, c := range courses {
+		cr, err := buildCourseResponseBody(c)
+		if err != nil {
+			return nil, err
 		}
+		responses = append(responses, cr)
 	}
-	return map[string]interface{}{
-		"courses": courses,
-	}, nil
+	return responses, nil
+}
+
+// NewCourseResponse は *model.Course から CourseResponseDataBody を構築します。
+func NewCourseResponse(course *model.Course) (CourseResponseDataBody, error) {
+	return buildCourseResponseBody(course)
+}
+
+// NewCreateCourseResponse は CourseID から CourseFormResponseData を構築します。
+func NewCreateCourseResponse(courseID uint) CourseFormResponseData {
+	return CourseFormResponseData{CourseId: int(courseID)}
 }

--- a/internal/interface/openapi/courses.go
+++ b/internal/interface/openapi/courses.go
@@ -1,12 +1,10 @@
 package openapi
 
-import (
-	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
-)
+import "github.com/daisuke-harada/date-courses-go/internal/domain/model"
 
 // NewCoursesResponse は []*model.Course から []CourseResponseDataBody を構築します。
-func NewCoursesResponse(courses []*model.Course) ([]CourseResponseDataBody, error) {
-	responses := make([]CourseResponseDataBody, 0, len(courses))
+func NewCoursesResponse(courses []*model.Course) ([]CourseResponseData, error) {
+	responses := make([]CourseResponseData, 0, len(courses))
 	for _, c := range courses {
 		cr, err := buildCourseResponseBody(c)
 		if err != nil {
@@ -17,8 +15,8 @@ func NewCoursesResponse(courses []*model.Course) ([]CourseResponseDataBody, erro
 	return responses, nil
 }
 
-// NewCourseResponse は *model.Course から CourseResponseDataBody を構築します。
-func NewCourseResponse(course *model.Course) (CourseResponseDataBody, error) {
+// NewCourseResponse は *model.Course から CourseResponseData を構築します。
+func NewCourseResponse(course *model.Course) (CourseResponseData, error) {
 	return buildCourseResponseBody(course)
 }
 

--- a/internal/interface/openapi/date_spot.go
+++ b/internal/interface/openapi/date_spot.go
@@ -1,1 +1,0 @@
-package openapi

--- a/internal/interface/openapi/date_spot_reviews.go
+++ b/internal/interface/openapi/date_spot_reviews.go
@@ -1,0 +1,51 @@
+package openapi
+
+import "github.com/daisuke-harada/date-courses-go/internal/domain/model"
+
+// NewDateSpotReviewResponse はレビュー一覧から DateSpotReviewResponseData を構築します。
+func NewDateSpotReviewResponse(reviews []*model.DateSpotReview) DateSpotReviewResponseData {
+	return DateSpotReviewResponseData{
+		DateSpotReviews:   toDateSpotReviewInners(reviews),
+		ReviewAverageRate: computeReviewAverageRate(reviews),
+	}
+}
+
+func toDateSpotReviewInners(reviews []*model.DateSpotReview) []DateSpotShowResponseDataDateSpotReviewsInner {
+	items := make([]DateSpotShowResponseDataDateSpotReviewsInner, 0, len(reviews))
+	for _, r := range reviews {
+		item := DateSpotShowResponseDataDateSpotReviewsInner{
+			Id:         int(r.ID),
+			DateSpotId: int(r.DateSpotID),
+			UserId:     int(r.UserID),
+		}
+		if r.Rate != nil {
+			f := float32(*r.Rate)
+			item.Rate = &f
+		}
+		if r.Content != nil {
+			item.Content = r.Content
+		}
+		if r.User != nil {
+			item.UserName = r.User.Name
+			item.UserGender = string(r.User.Gender)
+			item.UserImage = ImageData{Url: r.User.Image}
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func computeReviewAverageRate(reviews []*model.DateSpotReview) float32 {
+	var sum float64
+	var count int
+	for _, r := range reviews {
+		if r.Rate != nil {
+			sum += *r.Rate
+			count++
+		}
+	}
+	if count == 0 {
+		return 0
+	}
+	return float32(sum / float64(count))
+}

--- a/internal/interface/openapi/date_spots.go
+++ b/internal/interface/openapi/date_spots.go
@@ -5,108 +5,59 @@ import (
 
 	"github.com/daisuke-harada/date-courses-go/internal/domain/master"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
+	"github.com/samber/lo"
 )
 
-// DateSpotDataResponse は生成型 DateSpotData の代替で、
-// OpeningTime / ClosingTime を *time.Time にして null をそのまま JSON 出力します。
-type DateSpotDataResponse struct {
-	AverageRate float32    `json:"average_rate"`
-	ClosingTime *time.Time `json:"closing_time"`
-	CreatedAt   time.Time  `json:"created_at"`
-	GenreId     int        `json:"genre_id"`
-	Id          int        `json:"id"`
-	Image       ImageData  `json:"image"`
-	Name        string     `json:"name"`
-	OpeningTime *time.Time `json:"opening_time"`
-	UpdatedAt   time.Time  `json:"updated_at"`
-}
-
-// DateSpotSummaryDataResponse は生成型 DateSpotSummaryData の代替で、
-// DateSpot フィールドに DateSpotDataResponse を使います。
-type DateSpotSummaryDataResponse struct {
-	AverageRate       float32              `json:"average_rate"`
-	CityName          string               `json:"city_name"`
-	DateSpot          DateSpotDataResponse `json:"date_spot"`
-	GenreName         string               `json:"genre_name"`
-	Id                int                  `json:"id"`
-	Latitude          float32              `json:"latitude"`
-	Longitude         float32              `json:"longitude"`
-	PrefectureName    string               `json:"prefecture_name"`
-	ReviewTotalNumber int                  `json:"review_total_number"`
-}
-
-// DateSpotShowResponse は GET /api/v1/date_spots/:id のレスポンス型です。
-type DateSpotShowResponse struct {
-	DateSpot          DateSpotSummaryDataResponse `json:"date_spot"`
-	ReviewAverageRate float64                     `json:"review_average_rate"`
-	DateSpotReviews   []DateSpotReviewItem        `json:"date_spot_reviews"`
-}
-
-// DateSpotReviewItem はレビュー一覧の各要素です。
-type DateSpotReviewItem struct {
-	Id         int       `json:"id"`
-	Rate       *float64  `json:"rate"`
-	Content    *string   `json:"content"`
-	UserId     int       `json:"user_id"`
-	DateSpotId int       `json:"date_spot_id"`
-	UserName   string    `json:"user_name"`
-	UserGender string    `json:"user_gender"`
-	UserImage  ImageData `json:"user_image"`
-}
-
 // NewDateSpotShowResponse は DateSpot とレビュー一覧から DateSpotShowResponse を構築します。
-func NewDateSpotShowResponse(dateSpot *model.DateSpot, reviews []*model.DateSpotReview) DateSpotShowResponse {
-	return DateSpotShowResponse{
+func NewDateSpotShowResponse(dateSpot *model.DateSpot, reviews []*model.DateSpotReview) DateSpotShowResponseData {
+	return DateSpotShowResponseData{
 		DateSpot:          newDateSpotSummaryData(dateSpot),
-		ReviewAverageRate: dateSpot.AverageRate,
-		DateSpotReviews:   newDateSpotReviewItems(reviews),
+		ReviewAverageRate: float32(dateSpot.AverageRate),
+		DateSpotReviews:   newDateSpotShowResponseDataDateSpotReviewsInner(reviews),
 	}
 }
 
-func newDateSpotReviewItems(reviews []*model.DateSpotReview) []DateSpotReviewItem {
-	items := make([]DateSpotReviewItem, 0, len(reviews))
-	for _, r := range reviews {
-		item := DateSpotReviewItem{
+func newDateSpotShowResponseDataDateSpotReviewsInner(reviews []*model.DateSpotReview) []DateSpotShowResponseDataDateSpotReviewsInner {
+	return lo.Map(reviews, func(r *model.DateSpotReview, _ int) DateSpotShowResponseDataDateSpotReviewsInner {
+		item := DateSpotShowResponseDataDateSpotReviewsInner{
 			Id:         int(r.ID),
-			Rate:       r.Rate,
-			Content:    r.Content,
-			UserId:     int(r.UserID),
 			DateSpotId: int(r.DateSpotID),
+			UserId:     int(r.UserID),
+		}
+		if r.Rate != nil {
+			f := float32(*r.Rate)
+			item.Rate = &f
+		}
+		if r.Content != nil {
+			item.Content = r.Content
 		}
 		if r.User != nil {
 			item.UserName = r.User.Name
 			item.UserGender = string(r.User.Gender)
 			item.UserImage = ImageData{Url: r.User.Image}
 		}
-		items = append(items, item)
-	}
-	return items
+		return item
+	})
 }
 
-// NewCreateDateSpotResponse は DateSpotID から DateSpotFormResponseData を構築します。
 func NewCreateDateSpotResponse(dateSpotID uint) DateSpotFormResponseData {
 	return DateSpotFormResponseData{
 		DateSpotId: int(dateSpotID),
 	}
 }
 
-func NewDateSpotResponse(dateSpot *model.DateSpot) DateSpotSummaryDataResponse {
+func NewDateSpotResponse(dateSpot *model.DateSpot) DateSpotSummaryData {
 	return newDateSpotSummaryData(dateSpot)
 }
 
-func NewDateSpotsResponse(dateSpots []*model.DateSpot) []DateSpotSummaryDataResponse {
-	response := make([]DateSpotSummaryDataResponse, 0, len(dateSpots))
-	for _, ds := range dateSpots {
-		response = append(response, newDateSpotSummaryData(ds))
-	}
-	return response
+func NewDateSpotsResponse(dateSpots []*model.DateSpot) []DateSpotSummaryData {
+	return lo.Map(dateSpots, func(ds *model.DateSpot, _ int) DateSpotSummaryData {
+		return newDateSpotSummaryData(ds)
+	})
 }
 
-// NewDateSpotSummaries は生成型の []DateSpotSummaryData を返すヘルパーです。
-// Top のレスポンス（generated types）と互換にするために使います。
 func NewDateSpotSummaries(dateSpots []*model.DateSpot) []DateSpotSummaryData {
-	response := make([]DateSpotSummaryData, 0, len(dateSpots))
-	for _, ds := range dateSpots {
+	return lo.Map(dateSpots, func(ds *model.DateSpot, _ int) DateSpotSummaryData {
 		var (
 			latitude       float32
 			longitude      float32
@@ -151,7 +102,7 @@ func NewDateSpotSummaries(dateSpots []*model.DateSpot) []DateSpotSummaryData {
 			ClosingTime: closingTime,
 		}
 
-		response = append(response, DateSpotSummaryData{
+		return DateSpotSummaryData{
 			AverageRate:       float32(ds.AverageRate),
 			CityName:          ds.CityName,
 			DateSpot:          dateSpot,
@@ -161,12 +112,11 @@ func NewDateSpotSummaries(dateSpots []*model.DateSpot) []DateSpotSummaryData {
 			Longitude:         longitude,
 			PrefectureName:    prefectureName,
 			ReviewTotalNumber: ds.ReviewTotalNumber,
-		})
-	}
-	return response
+		}
+	})
 }
 
-func newDateSpotSummaryData(ds *model.DateSpot) DateSpotSummaryDataResponse {
+func newDateSpotSummaryData(ds *model.DateSpot) DateSpotSummaryData {
 	var (
 		latitude       float32
 		longitude      float32
@@ -186,7 +136,7 @@ func newDateSpotSummaryData(ds *model.DateSpot) DateSpotSummaryDataResponse {
 		prefectureName = master.PrefectureNameByID(*ds.PrefectureID)
 	}
 
-	return DateSpotSummaryDataResponse{
+	return DateSpotSummaryData{
 		Id:                int(ds.ID),
 		CityName:          ds.CityName,
 		Latitude:          latitude,
@@ -199,13 +149,21 @@ func newDateSpotSummaryData(ds *model.DateSpot) DateSpotSummaryDataResponse {
 	}
 }
 
-func newDateSpotData(ds *model.DateSpot) DateSpotDataResponse {
+func newDateSpotData(ds *model.DateSpot) DateSpotData {
 	var genreId int
 	if ds.GenreID != nil {
 		genreId = *ds.GenreID
 	}
 
-	return DateSpotDataResponse{
+	var openingTime, closingTime time.Time
+	if ds.OpeningTime != nil {
+		openingTime = *ds.OpeningTime
+	}
+	if ds.ClosingTime != nil {
+		closingTime = *ds.ClosingTime
+	}
+
+	return DateSpotData{
 		Id:          int(ds.ID),
 		Name:        ds.Name,
 		Image:       ImageData{Url: ds.Image},
@@ -213,7 +171,7 @@ func newDateSpotData(ds *model.DateSpot) DateSpotDataResponse {
 		AverageRate: float32(ds.AverageRate),
 		CreatedAt:   ds.CreatedAt,
 		UpdatedAt:   ds.UpdatedAt,
-		OpeningTime: ds.OpeningTime,
-		ClosingTime: ds.ClosingTime,
+		OpeningTime: openingTime,
+		ClosingTime: closingTime,
 	}
 }

--- a/internal/interface/openapi/relationship.go
+++ b/internal/interface/openapi/relationship.go
@@ -2,6 +2,42 @@ package openapi
 
 import "github.com/daisuke-harada/date-courses-go/internal/usecase"
 
+// UnFollowResponseBody は DELETE /api/v1/relationships のレスポンス型です。
+// UnFollowResponseData の互換型で、UserResponseBody を使います。
+type UnFollowResponseBody struct {
+	Users          []UserResponseBody `json:"users"`
+	CurrentUser    UserResponseBody   `json:"current_user"`
+	UnfollowedUser UserResponseBody   `json:"unfollowed_user"`
+}
+
+// BuildDeleteRelationshipResponse は DeleteRelationshipOutput から UnFollowResponseBody を構築します。
+func BuildDeleteRelationshipResponse(output *usecase.DeleteRelationshipOutput) (UnFollowResponseBody, error) {
+	users := make([]UserResponseBody, 0, len(output.Users))
+	for _, uwr := range output.Users {
+		resp, err := BuildUserResponseBody(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
+		if err != nil {
+			return UnFollowResponseBody{}, err
+		}
+		users = append(users, resp)
+	}
+
+	currentUser, err := NewUserWithRelationsResponse(output.CurrentUser)
+	if err != nil {
+		return UnFollowResponseBody{}, err
+	}
+
+	unfollowedUser, err := NewUserWithRelationsResponse(output.UnfollowedUser)
+	if err != nil {
+		return UnFollowResponseBody{}, err
+	}
+
+	return UnFollowResponseBody{
+		Users:          users,
+		CurrentUser:    currentUser,
+		UnfollowedUser: unfollowedUser,
+	}, nil
+}
+
 // CreateRelationshipResponseBody は POST /api/v1/relationships のレスポンス型です。
 type CreateRelationshipResponseBody struct {
 	Users        []UserResponseBody `json:"users"`

--- a/internal/interface/openapi/relationship.go
+++ b/internal/interface/openapi/relationship.go
@@ -2,72 +2,54 @@ package openapi
 
 import "github.com/daisuke-harada/date-courses-go/internal/usecase"
 
-// UnFollowResponseBody は DELETE /api/v1/relationships のレスポンス型です。
-// UnFollowResponseData の互換型で、UserResponseBody を使います。
-type UnFollowResponseBody struct {
-	Users          []UserResponseBody `json:"users"`
-	CurrentUser    UserResponseBody   `json:"current_user"`
-	UnfollowedUser UserResponseBody   `json:"unfollowed_user"`
-}
-
-// BuildDeleteRelationshipResponse は DeleteRelationshipOutput から UnFollowResponseBody を構築します。
-func BuildDeleteRelationshipResponse(output *usecase.DeleteRelationshipOutput) (UnFollowResponseBody, error) {
-	users := make([]UserResponseBody, 0, len(output.Users))
+func NewUnFollowResponseData(output *usecase.DeleteRelationshipOutput) (UnFollowResponseData, error) {
+	users := make([]UserResponseData, 0, len(output.Users))
 	for _, uwr := range output.Users {
-		resp, err := BuildUserResponseBody(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
+		resp, err := NewUserResponseData(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
 		if err != nil {
-			return UnFollowResponseBody{}, err
+			return UnFollowResponseData{}, err
 		}
 		users = append(users, resp)
 	}
 
 	currentUser, err := NewUserWithRelationsResponse(output.CurrentUser)
 	if err != nil {
-		return UnFollowResponseBody{}, err
+		return UnFollowResponseData{}, err
 	}
 
 	unfollowedUser, err := NewUserWithRelationsResponse(output.UnfollowedUser)
 	if err != nil {
-		return UnFollowResponseBody{}, err
+		return UnFollowResponseData{}, err
 	}
 
-	return UnFollowResponseBody{
+	return UnFollowResponseData{
 		Users:          users,
 		CurrentUser:    currentUser,
 		UnfollowedUser: unfollowedUser,
 	}, nil
 }
 
-// CreateRelationshipResponseBody は POST /api/v1/relationships のレスポンス型です。
-type CreateRelationshipResponseBody struct {
-	Users        []UserResponseBody `json:"users"`
-	CurrentUser  UserResponseBody   `json:"current_user"`
-	FollowedUser UserResponseBody   `json:"followed_user"`
-}
-
-// BuildCreateRelationshipResponse は CreateRelationshipOutput から
-// CreateRelationshipResponseBody を構築します。
-func BuildCreateRelationshipResponse(output *usecase.CreateRelationshipOutput) (CreateRelationshipResponseBody, error) {
-	users := make([]UserResponseBody, 0, len(output.Users))
+func NewFollowResponseData(output *usecase.CreateRelationshipOutput) (FollowResponseData, error) {
+	users := make([]UserResponseData, 0, len(output.Users))
 	for _, uwr := range output.Users {
-		resp, err := BuildUserResponseBody(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
+		resp, err := NewUserResponseData(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
 		if err != nil {
-			return CreateRelationshipResponseBody{}, err
+			return FollowResponseData{}, err
 		}
 		users = append(users, resp)
 	}
 
 	currentUser, err := NewUserWithRelationsResponse(output.CurrentUser)
 	if err != nil {
-		return CreateRelationshipResponseBody{}, err
+		return FollowResponseData{}, err
 	}
 
 	followedUser, err := NewUserWithRelationsResponse(output.FollowedUser)
 	if err != nil {
-		return CreateRelationshipResponseBody{}, err
+		return FollowResponseData{}, err
 	}
 
-	return CreateRelationshipResponseBody{
+	return FollowResponseData{
 		Users:        users,
 		CurrentUser:  currentUser,
 		FollowedUser: followedUser,

--- a/internal/interface/openapi/users.go
+++ b/internal/interface/openapi/users.go
@@ -4,69 +4,33 @@ import (
 	"github.com/daisuke-harada/date-courses-go/internal/domain/master"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/oapi-codegen/runtime/types"
+	"github.com/samber/lo"
 )
 
-// UserResponseBody は UserResponseData の代替型です。
-// CourseResponseDataBody / DateSpotReviewDataBody を使うことで
-// OpeningTime / ClosingTime の nullable を正しく扱います。
-type UserResponseBody struct {
-	Admin           bool                     `json:"admin"`
-	Courses         []CourseResponseDataBody `json:"courses"`
-	DateSpotReviews []DateSpotReviewDataBody `json:"date_spot_reviews"`
-	Email           string                   `json:"email"`
-	FollowerIds     []int                    `json:"followerIds"`
-	FollowingIds    []int                    `json:"followingIds"`
-	Gender          Gender                   `json:"gender"`
-	Id              int                      `json:"id"`
-	Image           ImageData                `json:"image"`
-	Name            string                   `json:"name"`
-}
-
-// CourseResponseDataBody は CourseResponseData の代替型です。
-// DateSpots フィールドに DateSpotSummaryDataResponse を使います。
-type CourseResponseDataBody struct {
-	Authority                  string                        `json:"authority"`
-	DateSpots                  []DateSpotSummaryDataResponse `json:"date_spots"`
-	Id                         int                           `json:"id"`
-	NoDuplicatePrefectureNames []string                      `json:"no_duplicate_prefecture_names"`
-	TravelMode                 string                        `json:"travel_mode"`
-	User                       UserData                      `json:"user"`
-}
-
-// DateSpotReviewDataBody は DateSpotReviewData の代替型です。
-// DateSpot フィールドに DateSpotDataResponse を使います。
-type DateSpotReviewDataBody struct {
-	Content  string               `json:"content"`
-	DateSpot DateSpotDataResponse `json:"date_spot"`
-	Id       int                  `json:"id"`
-	Rate     float32              `json:"rate"`
-}
-
-// BuildUserResponseBody は User と関連データから UserResponseBody を構築します。
-func BuildUserResponseBody(
+// NewUserResponseData は User と関連データから UserResponseBody を構築します。
+func NewUserResponseData(
 	user *model.User,
 	followerIDs, followingIDs []int,
 	courses []*model.Course,
 	reviews []*model.DateSpotReview,
-) (UserResponseBody, error) {
+) (UserResponseData, error) {
 	gender, err := NewGender(user.Gender)
 	if err != nil {
-		return UserResponseBody{}, err
+		return UserResponseData{}, err
 	}
 
-	courseResponses := make([]CourseResponseDataBody, 0, len(courses))
+	courseResponses := make([]CourseResponseData, 0, len(courses))
 	for _, c := range courses {
 		cr, err := buildCourseResponseBody(c)
 		if err != nil {
-			return UserResponseBody{}, err
+			return UserResponseData{}, err
 		}
 		courseResponses = append(courseResponses, cr)
 	}
 
-	reviewResponses := make([]DateSpotReviewDataBody, 0, len(reviews))
-	for _, rv := range reviews {
-		reviewResponses = append(reviewResponses, buildDateSpotReviewDataBody(rv))
-	}
+	reviewResponses := lo.Map(reviews, func(rv *model.DateSpotReview, _ int) DateSpotReviewData {
+		return newDateSpotReviewData(rv)
+	})
 
 	if followerIDs == nil {
 		followerIDs = []int{}
@@ -75,7 +39,7 @@ func BuildUserResponseBody(
 		followingIDs = []int{}
 	}
 
-	return UserResponseBody{
+	return UserResponseData{
 		Id:              int(user.ID),
 		Admin:           user.Admin,
 		Email:           user.Email,
@@ -89,10 +53,8 @@ func BuildUserResponseBody(
 	}, nil
 }
 
-// buildCourseResponseBody は Course モデルから CourseResponseDataBody を構築します。
-// Course.User と Course.DuringSpots.DateSpot が Preload 済みであることを前提とします。
-func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, error) {
-	dateSpots := make([]DateSpotSummaryDataResponse, 0, len(course.DuringSpots))
+func buildCourseResponseBody(course *model.Course) (CourseResponseData, error) {
+	dateSpots := make([]DateSpotSummaryData, 0, len(course.DuringSpots))
 	prefectureIDSet := make(map[int]struct{})
 
 	for _, ds := range course.DuringSpots {
@@ -117,7 +79,7 @@ func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, erro
 	if course.User != nil {
 		gender, err := NewGender(course.User.Gender)
 		if err != nil {
-			return CourseResponseDataBody{}, err
+			return CourseResponseData{}, err
 		}
 		courseUser = UserData{
 			Id:     int(course.User.ID),
@@ -129,7 +91,7 @@ func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, erro
 		}
 	}
 
-	return CourseResponseDataBody{
+	return CourseResponseData{
 		Id:                         int(course.ID),
 		Authority:                  course.Authority,
 		TravelMode:                 course.TravelMode,
@@ -139,9 +101,7 @@ func buildCourseResponseBody(course *model.Course) (CourseResponseDataBody, erro
 	}, nil
 }
 
-// buildDateSpotReviewDataBody は DateSpotReview から DateSpotReviewDataBody を構築します。
-// Review.DateSpot が Preload 済みであることを前提とします。
-func buildDateSpotReviewDataBody(review *model.DateSpotReview) DateSpotReviewDataBody {
+func newDateSpotReviewData(review *model.DateSpotReview) DateSpotReviewData {
 	var rate float32
 	if review.Rate != nil {
 		rate = float32(*review.Rate)
@@ -151,12 +111,12 @@ func buildDateSpotReviewDataBody(review *model.DateSpotReview) DateSpotReviewDat
 		content = *review.Content
 	}
 
-	var dateSpot DateSpotDataResponse
+	var dateSpot DateSpotData
 	if review.DateSpot != nil {
 		dateSpot = newDateSpotData(review.DateSpot)
 	}
 
-	return DateSpotReviewDataBody{
+	return DateSpotReviewData{
 		Id:       int(review.ID),
 		Rate:     rate,
 		Content:  content,
@@ -164,11 +124,10 @@ func buildDateSpotReviewDataBody(review *model.DateSpotReview) DateSpotReviewDat
 	}
 }
 
-// NewGetUsersResponse は output.Users から []UserResponseBody を構築します。
-func NewGetUsersResponse(users []*model.UserWithRelations) ([]UserResponseBody, error) {
-	responses := make([]UserResponseBody, 0, len(users))
+func NewGetUsersResponse(users []*model.UserWithRelations) ([]UserResponseData, error) {
+	responses := make([]UserResponseData, 0, len(users))
 	for _, uwr := range users {
-		resp, err := BuildUserResponseBody(
+		resp, err := NewUserResponseData(
 			uwr.User,
 			uwr.FollowerIDs,
 			uwr.FollowingIDs,
@@ -184,6 +143,6 @@ func NewGetUsersResponse(users []*model.UserWithRelations) ([]UserResponseBody, 
 }
 
 // NewUserWithRelationsResponse は *model.UserWithRelations から UserResponseBody を構築します。
-func NewUserWithRelationsResponse(uwr *model.UserWithRelations) (UserResponseBody, error) {
-	return BuildUserResponseBody(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
+func NewUserWithRelationsResponse(uwr *model.UserWithRelations) (UserResponseData, error) {
+	return NewUserResponseData(uwr.User, uwr.FollowerIDs, uwr.FollowingIDs, uwr.Courses, uwr.Reviews)
 }

--- a/internal/usecase/create_date_spot_review.go
+++ b/internal/usecase/create_date_spot_review.go
@@ -35,23 +35,15 @@ func (i *CreateDateSpotReviewInput) Validate() error {
 
 type CreateDateSpotReviewOutput struct {
 	ReviewID        uint
-	DateSpot        *model.DateSpot
 	DateSpotReviews []*model.DateSpotReview
 }
 
 type CreateDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
-	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewCreateDateSpotReviewUsecase(
-	dateSpotReviewRepository repository.DateSpotReviewRepository,
-	dateSpotRepository repository.DateSpotRepository,
-) CreateDateSpotReviewInputPort {
-	return &CreateDateSpotReviewInteractor{
-		DateSpotReviewRepository: dateSpotReviewRepository,
-		DateSpotRepository:       dateSpotRepository,
-	}
+func NewCreateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) CreateDateSpotReviewInputPort {
+	return &CreateDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
 }
 
 func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input CreateDateSpotReviewInput) (*CreateDateSpotReviewOutput, error) {
@@ -68,11 +60,6 @@ func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input Crea
 		return nil, apperror.InternalServerError(err)
 	}
 
-	dateSpot, err := i.DateSpotRepository.FindByID(ctx, input.DateSpotID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
 	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, input.DateSpotID)
 	if err != nil {
 		return nil, apperror.InternalServerError(err)
@@ -80,7 +67,6 @@ func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input Crea
 
 	return &CreateDateSpotReviewOutput{
 		ReviewID:        review.ID,
-		DateSpot:        dateSpot,
 		DateSpotReviews: reviews,
 	}, nil
 }

--- a/internal/usecase/create_date_spot_review.go
+++ b/internal/usecase/create_date_spot_review.go
@@ -2,6 +2,8 @@ package usecase
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
@@ -27,10 +29,61 @@ func (i *CreateDateSpotReviewInput) Validate() error {
 	if i.DateSpotID == 0 {
 		errs = append(errs, "デートスポットIDを入力してください")
 	}
+	if i.Rate != nil {
+		if *i.Rate < 0 || *i.Rate > 5 {
+			errs = append(errs, "rate は 0 以上 5 以下で指定してください")
+		}
+	}
+	if i.Content != nil {
+		if strings.TrimSpace(*i.Content) == "" {
+			errs = append(errs, "content を入力してください")
+		} else if len(*i.Content) > 1000 {
+			errs = append(errs, "content は1000文字以内で入力してください")
+		}
+	}
 	if len(errs) > 0 {
 		return apperror.UnprocessableEntity(errs...)
 	}
 	return nil
+}
+
+// NewCreateDateSpotReviewInputFromStrings builds CreateDateSpotReviewInput from raw string values.
+// It performs type parsing (user_id/date_spot_id/rate) and returns BadRequest on parse errors.
+func NewCreateDateSpotReviewInputFromStrings(userIDStr, dateSpotIDStr, rateStr, contentStr string) (CreateDateSpotReviewInput, error) {
+	// parse user id
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		return CreateDateSpotReviewInput{}, apperror.BadRequest("user_id は整数で指定してください")
+	}
+	// parse date spot id
+	dateSpotID, err := strconv.Atoi(dateSpotIDStr)
+	if err != nil {
+		return CreateDateSpotReviewInput{}, apperror.BadRequest("date_spot_id は整数で指定してください")
+	}
+
+	// parse rate (optional)
+	var rate *float64
+	if rateStr != "" {
+		r, err := strconv.ParseFloat(rateStr, 64)
+		if err != nil {
+			return CreateDateSpotReviewInput{}, apperror.BadRequest("rate は数値で指定してください")
+		}
+		rate = &r
+	}
+
+	// content (optional)
+	var content *string
+	if contentStr != "" {
+		s := contentStr
+		content = &s
+	}
+
+	return CreateDateSpotReviewInput{
+		UserID:     uint(userID),
+		DateSpotID: uint(dateSpotID),
+		Rate:       rate,
+		Content:    content,
+	}, nil
 }
 
 type CreateDateSpotReviewOutput struct {

--- a/internal/usecase/create_date_spot_review.go
+++ b/internal/usecase/create_date_spot_review.go
@@ -34,15 +34,24 @@ func (i *CreateDateSpotReviewInput) Validate() error {
 }
 
 type CreateDateSpotReviewOutput struct {
-	ReviewID uint
+	ReviewID        uint
+	DateSpot        *model.DateSpot
+	DateSpotReviews []*model.DateSpotReview
 }
 
 type CreateDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
+	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewCreateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) CreateDateSpotReviewInputPort {
-	return &CreateDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
+func NewCreateDateSpotReviewUsecase(
+	dateSpotReviewRepository repository.DateSpotReviewRepository,
+	dateSpotRepository repository.DateSpotRepository,
+) CreateDateSpotReviewInputPort {
+	return &CreateDateSpotReviewInteractor{
+		DateSpotReviewRepository: dateSpotReviewRepository,
+		DateSpotRepository:       dateSpotRepository,
+	}
 }
 
 func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input CreateDateSpotReviewInput) (*CreateDateSpotReviewOutput, error) {
@@ -58,5 +67,20 @@ func (i *CreateDateSpotReviewInteractor) Execute(ctx context.Context, input Crea
 	if err := i.DateSpotReviewRepository.Create(ctx, review); err != nil {
 		return nil, apperror.InternalServerError(err)
 	}
-	return &CreateDateSpotReviewOutput{ReviewID: review.ID}, nil
+
+	dateSpot, err := i.DateSpotRepository.FindByID(ctx, input.DateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, input.DateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	return &CreateDateSpotReviewOutput{
+		ReviewID:        review.ID,
+		DateSpot:        dateSpot,
+		DateSpotReviews: reviews,
+	}, nil
 }

--- a/internal/usecase/create_date_spot_review_test.go
+++ b/internal/usecase/create_date_spot_review_test.go
@@ -32,8 +32,16 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 				r.ID = 10
 				return nil
 			})
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(2)).
+			Return([]*model.DateSpotReview{}, nil)
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			FindByID(ctx, uint(2)).
+			Return(&model.DateSpot{ID: 2, Name: "テストスポット"}, nil)
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 2,
@@ -43,6 +51,8 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, uint(10), output.ReviewID)
+		assert.NotNil(t, output.DateSpot)
+		assert.NotNil(t, output.DateSpotReviews)
 	})
 
 	t.Run("error_validation_missing_user_id", func(t *testing.T) {
@@ -50,9 +60,9 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		// リポジトリは呼ばれない
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     0,
 			DateSpotID: 2,
@@ -70,9 +80,9 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		// リポジトリは呼ばれない
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 0,
@@ -94,7 +104,9 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 			Create(ctx, gomock.Any()).
 			Return(errors.New("db error"))
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 2,

--- a/internal/usecase/create_date_spot_review_test.go
+++ b/internal/usecase/create_date_spot_review_test.go
@@ -36,12 +36,7 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 			FindByDateSpotID(ctx, uint(2)).
 			Return([]*model.DateSpotReview{}, nil)
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-		dateSpotRepo.EXPECT().
-			FindByID(ctx, uint(2)).
-			Return(&model.DateSpot{ID: 2, Name: "テストスポット"}, nil)
-
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 2,
@@ -51,7 +46,6 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, uint(10), output.ReviewID)
-		assert.NotNil(t, output.DateSpot)
 		assert.NotNil(t, output.DateSpotReviews)
 	})
 
@@ -60,9 +54,8 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     0,
 			DateSpotID: 2,
@@ -80,9 +73,8 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 0,
@@ -104,9 +96,7 @@ func TestCreateDateSpotReviewInteractor_Execute(t *testing.T) {
 			Create(ctx, gomock.Any()).
 			Return(errors.New("db error"))
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-
-		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewCreateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.CreateDateSpotReviewInput{
 			UserID:     1,
 			DateSpotID: 2,

--- a/internal/usecase/create_relationship.go
+++ b/internal/usecase/create_relationship.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
@@ -27,6 +28,18 @@ func (i *CreateRelationshipInput) Validate() error {
 	}
 
 	return nil
+}
+
+func NewCreateRelationshipInputFromStrings(currentUserIDStr, followedUserIDStr string) (CreateRelationshipInput, error) {
+	cur, err := strconv.Atoi(currentUserIDStr)
+	if err != nil {
+		return CreateRelationshipInput{}, apperror.BadRequest("current_user_id は数値で指定してください")
+	}
+	fol, err := strconv.Atoi(followedUserIDStr)
+	if err != nil {
+		return CreateRelationshipInput{}, apperror.BadRequest("followed_user_id は数値で指定してください")
+	}
+	return CreateRelationshipInput{CurrentUserID: uint(cur), FollowedUserID: uint(fol)}, nil
 }
 
 type CreateRelationshipOutput struct {

--- a/internal/usecase/delete_date_spot_review.go
+++ b/internal/usecase/delete_date_spot_review.go
@@ -4,28 +4,61 @@ import (
 	"context"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
 )
 
 type DeleteDateSpotReviewInputPort interface {
-	Execute(context.Context, DeleteDateSpotReviewInput) error
+	Execute(context.Context, DeleteDateSpotReviewInput) (*DeleteDateSpotReviewOutput, error)
 }
 
 type DeleteDateSpotReviewInput struct {
 	ReviewID uint
 }
 
+type DeleteDateSpotReviewOutput struct {
+	DateSpot        *model.DateSpot
+	DateSpotReviews []*model.DateSpotReview
+}
+
 type DeleteDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
+	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewDeleteDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) DeleteDateSpotReviewInputPort {
-	return &DeleteDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
-}
-
-func (i *DeleteDateSpotReviewInteractor) Execute(ctx context.Context, input DeleteDateSpotReviewInput) error {
-	if err := i.DateSpotReviewRepository.DeleteByID(ctx, input.ReviewID); err != nil {
-		return apperror.InternalServerError(err)
+func NewDeleteDateSpotReviewUsecase(
+	dateSpotReviewRepository repository.DateSpotReviewRepository,
+	dateSpotRepository repository.DateSpotRepository,
+) DeleteDateSpotReviewInputPort {
+	return &DeleteDateSpotReviewInteractor{
+		DateSpotReviewRepository: dateSpotReviewRepository,
+		DateSpotRepository:       dateSpotRepository,
 	}
-	return nil
+}
+
+func (i *DeleteDateSpotReviewInteractor) Execute(ctx context.Context, input DeleteDateSpotReviewInput) (*DeleteDateSpotReviewOutput, error) {
+	review, err := i.DateSpotReviewRepository.FindByID(ctx, input.ReviewID)
+	if err != nil {
+		return nil, apperror.NotFound()
+	}
+	dateSpotID := review.DateSpotID
+
+	if err := i.DateSpotReviewRepository.DeleteByID(ctx, input.ReviewID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	dateSpot, err := i.DateSpotRepository.FindByID(ctx, dateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, dateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	return &DeleteDateSpotReviewOutput{
+		DateSpot:        dateSpot,
+		DateSpotReviews: reviews,
+	}, nil
 }

--- a/internal/usecase/delete_date_spot_review.go
+++ b/internal/usecase/delete_date_spot_review.go
@@ -17,23 +17,15 @@ type DeleteDateSpotReviewInput struct {
 }
 
 type DeleteDateSpotReviewOutput struct {
-	DateSpot        *model.DateSpot
 	DateSpotReviews []*model.DateSpotReview
 }
 
 type DeleteDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
-	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewDeleteDateSpotReviewUsecase(
-	dateSpotReviewRepository repository.DateSpotReviewRepository,
-	dateSpotRepository repository.DateSpotRepository,
-) DeleteDateSpotReviewInputPort {
-	return &DeleteDateSpotReviewInteractor{
-		DateSpotReviewRepository: dateSpotReviewRepository,
-		DateSpotRepository:       dateSpotRepository,
-	}
+func NewDeleteDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) DeleteDateSpotReviewInputPort {
+	return &DeleteDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
 }
 
 func (i *DeleteDateSpotReviewInteractor) Execute(ctx context.Context, input DeleteDateSpotReviewInput) (*DeleteDateSpotReviewOutput, error) {
@@ -47,18 +39,12 @@ func (i *DeleteDateSpotReviewInteractor) Execute(ctx context.Context, input Dele
 		return nil, apperror.InternalServerError(err)
 	}
 
-	dateSpot, err := i.DateSpotRepository.FindByID(ctx, dateSpotID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
 	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, dateSpotID)
 	if err != nil {
 		return nil, apperror.InternalServerError(err)
 	}
 
 	return &DeleteDateSpotReviewOutput{
-		DateSpot:        dateSpot,
 		DateSpotReviews: reviews,
 	}, nil
 }

--- a/internal/usecase/delete_date_spot_review_test.go
+++ b/internal/usecase/delete_date_spot_review_test.go
@@ -3,8 +3,11 @@ package usecase_test
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
+	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/stretchr/testify/assert"
@@ -21,13 +24,47 @@ func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
+			FindByID(ctx, uint(10)).
+			Return(&model.DateSpotReview{ID: 10, DateSpotID: 5}, nil)
+		reviewRepo.EXPECT().
 			DeleteByID(ctx, uint(10)).
 			Return(nil)
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(5)).
+			Return([]*model.DateSpotReview{}, nil)
 
-		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
-		err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			FindByID(ctx, uint(5)).
+			Return(&model.DateSpot{ID: 5, Name: "テストスポット"}, nil)
+
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
 
 		require.NoError(t, err)
+		assert.NotNil(t, output)
+		assert.NotNil(t, output.DateSpot)
+	})
+
+	t.Run("error_review_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			FindByID(ctx, uint(10)).
+			Return(nil, errors.New("not found"))
+
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
 	})
 
 	t.Run("error_repository_delete_failed", func(t *testing.T) {
@@ -36,12 +73,18 @@ func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
+			FindByID(ctx, uint(10)).
+			Return(&model.DateSpotReview{ID: 10, DateSpotID: 5}, nil)
+		reviewRepo.EXPECT().
 			DeleteByID(ctx, uint(10)).
 			Return(errors.New("db error"))
 
-		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
-		err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
 
 		assert.Error(t, err)
+		assert.Nil(t, output)
 	})
 }

--- a/internal/usecase/delete_date_spot_review_test.go
+++ b/internal/usecase/delete_date_spot_review_test.go
@@ -33,17 +33,12 @@ func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
 			FindByDateSpotID(ctx, uint(5)).
 			Return([]*model.DateSpotReview{}, nil)
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-		dateSpotRepo.EXPECT().
-			FindByID(ctx, uint(5)).
-			Return(&model.DateSpot{ID: 5, Name: "テストスポット"}, nil)
-
-		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
 
 		require.NoError(t, err)
 		assert.NotNil(t, output)
-		assert.NotNil(t, output.DateSpot)
+		assert.NotNil(t, output.DateSpotReviews)
 	})
 
 	t.Run("error_review_not_found", func(t *testing.T) {
@@ -55,9 +50,7 @@ func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
 			FindByID(ctx, uint(10)).
 			Return(nil, errors.New("not found"))
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-
-		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
 
 		assert.Error(t, err)
@@ -79,9 +72,7 @@ func TestDeleteDateSpotReviewInteractor_Execute(t *testing.T) {
 			DeleteByID(ctx, uint(10)).
 			Return(errors.New("db error"))
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-
-		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewDeleteDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.DeleteDateSpotReviewInput{ReviewID: 10})
 
 		assert.Error(t, err)

--- a/internal/usecase/delete_relationship.go
+++ b/internal/usecase/delete_relationship.go
@@ -4,11 +4,13 @@ import (
 	"context"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/repository"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/service"
 )
 
 type DeleteRelationshipInputPort interface {
-	Execute(context.Context, DeleteRelationshipInput) error
+	Execute(context.Context, DeleteRelationshipInput) (*DeleteRelationshipOutput, error)
 }
 
 type DeleteRelationshipInput struct {
@@ -16,17 +18,68 @@ type DeleteRelationshipInput struct {
 	FollowID uint
 }
 
+type DeleteRelationshipOutput struct {
+	Users          []*model.UserWithRelations
+	CurrentUser    *model.UserWithRelations
+	UnfollowedUser *model.UserWithRelations
+}
+
 type DeleteRelationshipInteractor struct {
 	RelationshipRepository repository.RelationshipRepository
+	UserRepository         repository.UserRepository
+	UserService            service.UserService
 }
 
-func NewDeleteRelationshipUsecase(relationshipRepository repository.RelationshipRepository) DeleteRelationshipInputPort {
-	return &DeleteRelationshipInteractor{RelationshipRepository: relationshipRepository}
-}
-
-func (i *DeleteRelationshipInteractor) Execute(ctx context.Context, input DeleteRelationshipInput) error {
-	if err := i.RelationshipRepository.DeleteByUserIDs(ctx, input.UserID, input.FollowID); err != nil {
-		return apperror.InternalServerError(err)
+func NewDeleteRelationshipUsecase(
+	relationshipRepository repository.RelationshipRepository,
+	userRepository repository.UserRepository,
+	userService service.UserService,
+) DeleteRelationshipInputPort {
+	return &DeleteRelationshipInteractor{
+		RelationshipRepository: relationshipRepository,
+		UserRepository:         userRepository,
+		UserService:            userService,
 	}
-	return nil
+}
+
+func (i *DeleteRelationshipInteractor) Execute(ctx context.Context, input DeleteRelationshipInput) (*DeleteRelationshipOutput, error) {
+	currentUser, err := i.UserRepository.FindByID(ctx, input.UserID)
+	if err != nil {
+		return nil, apperror.NotFound()
+	}
+
+	unfollowedUser, err := i.UserRepository.FindByID(ctx, input.FollowID)
+	if err != nil {
+		return nil, apperror.NotFound()
+	}
+
+	if err := i.RelationshipRepository.DeleteByUserIDs(ctx, input.UserID, input.FollowID); err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	allUsers, err := i.UserRepository.Search(ctx, nil)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	usersWithRelations, err := i.UserService.BuildUsersWithRelations(ctx, allUsers)
+	if err != nil {
+		return nil, err
+	}
+
+	currentUwr, err := i.UserService.BuildUserWithRelations(ctx, currentUser)
+	if err != nil {
+		return nil, err
+	}
+
+	unfollowedUwr, err := i.UserService.BuildUserWithRelations(ctx, unfollowedUser)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DeleteRelationshipOutput{
+		Users:          usersWithRelations,
+		CurrentUser:    currentUwr,
+		UnfollowedUser: unfollowedUwr,
+	}, nil
 }

--- a/internal/usecase/delete_relationship_test.go
+++ b/internal/usecase/delete_relationship_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
+	servicemock "github.com/daisuke-harada/date-courses-go/internal/domain/service/mock"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,22 +17,59 @@ import (
 func TestDeleteRelationshipInteractor_Execute(t *testing.T) {
 	ctx := context.Background()
 
+	currentUser := &model.User{ID: 1, Name: "current", Email: "current@example.com", Gender: "男性"}
+	unfollowedUser := &model.User{ID: 2, Name: "unfollowed", Email: "unfollowed@example.com", Gender: "女性"}
+	uwr := &model.UserWithRelations{User: currentUser, FollowerIDs: []int{}, FollowingIDs: []int{}}
+	unfollowedUwr := &model.UserWithRelations{User: unfollowedUser, FollowerIDs: []int{}, FollowingIDs: []int{}}
+
 	t.Run("success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		relationshipRepo := repomock.NewMockRelationshipRepository(ctrl)
-		relationshipRepo.EXPECT().
-			DeleteByUserIDs(ctx, uint(1), uint(2)).
-			Return(nil)
+		userRepo := repomock.NewMockUserRepository(ctrl)
+		userService := servicemock.NewMockUserService(ctrl)
 
-		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo)
-		err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
+		userRepo.EXPECT().FindByID(ctx, uint(1)).Return(currentUser, nil)
+		userRepo.EXPECT().FindByID(ctx, uint(2)).Return(unfollowedUser, nil)
+		relationshipRepo.EXPECT().DeleteByUserIDs(ctx, uint(1), uint(2)).Return(nil)
+		userRepo.EXPECT().Search(ctx, nil).Return([]*model.User{currentUser, unfollowedUser}, nil)
+		userService.EXPECT().
+			BuildUsersWithRelations(ctx, gomock.Any()).
+			Return([]*model.UserWithRelations{uwr, unfollowedUwr}, nil)
+		userService.EXPECT().BuildUserWithRelations(ctx, currentUser).Return(uwr, nil)
+		userService.EXPECT().BuildUserWithRelations(ctx, unfollowedUser).Return(unfollowedUwr, nil)
+
+		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo, userRepo, userService)
+		output, err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
 			UserID:   1,
 			FollowID: 2,
 		})
 
 		require.NoError(t, err)
+		assert.NotNil(t, output)
+		assert.NotNil(t, output.CurrentUser)
+		assert.NotNil(t, output.UnfollowedUser)
+	})
+
+	t.Run("error_current_user_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		relationshipRepo := repomock.NewMockRelationshipRepository(ctrl)
+		userRepo := repomock.NewMockUserRepository(ctrl)
+		userService := servicemock.NewMockUserService(ctrl)
+
+		userRepo.EXPECT().FindByID(ctx, uint(1)).Return(nil, errors.New("not found"))
+
+		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo, userRepo, userService)
+		output, err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
+			UserID:   1,
+			FollowID: 2,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
 	})
 
 	t.Run("error_repository_delete_failed", func(t *testing.T) {
@@ -38,16 +77,20 @@ func TestDeleteRelationshipInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		relationshipRepo := repomock.NewMockRelationshipRepository(ctrl)
-		relationshipRepo.EXPECT().
-			DeleteByUserIDs(ctx, uint(1), uint(2)).
-			Return(errors.New("db error"))
+		userRepo := repomock.NewMockUserRepository(ctrl)
+		userService := servicemock.NewMockUserService(ctrl)
 
-		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo)
-		err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
+		userRepo.EXPECT().FindByID(ctx, uint(1)).Return(currentUser, nil)
+		userRepo.EXPECT().FindByID(ctx, uint(2)).Return(unfollowedUser, nil)
+		relationshipRepo.EXPECT().DeleteByUserIDs(ctx, uint(1), uint(2)).Return(errors.New("db error"))
+
+		interactor := usecase.NewDeleteRelationshipUsecase(relationshipRepo, userRepo, userService)
+		output, err := interactor.Execute(ctx, usecase.DeleteRelationshipInput{
 			UserID:   1,
 			FollowID: 2,
 		})
 
 		assert.Error(t, err)
+		assert.Nil(t, output)
 	})
 }

--- a/internal/usecase/mock/delete_date_spot_review.go
+++ b/internal/usecase/mock/delete_date_spot_review.go
@@ -42,11 +42,12 @@ func (m *MockDeleteDateSpotReviewInputPort) EXPECT() *MockDeleteDateSpotReviewIn
 }
 
 // Execute mocks base method.
-func (m *MockDeleteDateSpotReviewInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteDateSpotReviewInput) error {
+func (m *MockDeleteDateSpotReviewInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteDateSpotReviewInput) (*usecase.DeleteDateSpotReviewOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*usecase.DeleteDateSpotReviewOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.

--- a/internal/usecase/mock/delete_relationship.go
+++ b/internal/usecase/mock/delete_relationship.go
@@ -42,11 +42,12 @@ func (m *MockDeleteRelationshipInputPort) EXPECT() *MockDeleteRelationshipInputP
 }
 
 // Execute mocks base method.
-func (m *MockDeleteRelationshipInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteRelationshipInput) error {
+func (m *MockDeleteRelationshipInputPort) Execute(arg0 context.Context, arg1 usecase.DeleteRelationshipInput) (*usecase.DeleteRelationshipOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Execute", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*usecase.DeleteRelationshipOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Execute indicates an expected call of Execute.

--- a/internal/usecase/signup.go
+++ b/internal/usecase/signup.go
@@ -141,3 +141,33 @@ func (i *SignupInteractor) Execute(ctx context.Context, input SignupInput) (*Sig
 
 	return out, nil
 }
+
+// NewSignupInput builds SignupInput from raw string form values.
+// It converts gender string to model.Gender when possible. If genderStr is empty or invalid,
+// the zero value is used and validation will catch it.
+func NewSignupInput(name, email, genderStr, password, passwordConfirmation, imageStr string) (SignupInput, error) {
+	var gender model.Gender
+	if genderStr != "" {
+		g := model.Gender(genderStr)
+		if g == model.GenderMale || g == model.GenderFemale {
+			gender = g
+		} else {
+			// invalid gender -> treat as empty and let Validate() handle it
+			gender = ""
+		}
+	}
+
+	var image *string
+	if imageStr != "" {
+		image = &imageStr
+	}
+
+	return SignupInput{
+		Name:                 name,
+		Email:                email,
+		Gender:               gender,
+		Password:             password,
+		PasswordConfirmation: passwordConfirmation,
+		Image:                image,
+	}, nil
+}

--- a/internal/usecase/update_date_spot_review.go
+++ b/internal/usecase/update_date_spot_review.go
@@ -13,13 +13,12 @@ type UpdateDateSpotReviewInputPort interface {
 }
 
 type UpdateDateSpotReviewInput struct {
-	ReviewID uint
-	Rate     *float64
-	Content  *string
+	ReviewID   uint
+	DateSpotID uint
+	Rate       *float64
+	Content    *string
 }
 
-// Validate はレビュー更新の入力バリデーションを行います。
-// rate または content のいずれかが必要です。
 func (i *UpdateDateSpotReviewInput) Validate() error {
 	if i.Rate == nil && i.Content == nil {
 		return apperror.UnprocessableEntity("rate または content のいずれかを入力してください")
@@ -29,35 +28,21 @@ func (i *UpdateDateSpotReviewInput) Validate() error {
 
 type UpdateDateSpotReviewOutput struct {
 	ReviewID        uint
-	DateSpot        *model.DateSpot
 	DateSpotReviews []*model.DateSpotReview
 }
 
 type UpdateDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
-	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewUpdateDateSpotReviewUsecase(
-	dateSpotReviewRepository repository.DateSpotReviewRepository,
-	dateSpotRepository repository.DateSpotRepository,
-) UpdateDateSpotReviewInputPort {
-	return &UpdateDateSpotReviewInteractor{
-		DateSpotReviewRepository: dateSpotReviewRepository,
-		DateSpotRepository:       dateSpotRepository,
-	}
+func NewUpdateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) UpdateDateSpotReviewInputPort {
+	return &UpdateDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
 }
 
 func (i *UpdateDateSpotReviewInteractor) Execute(ctx context.Context, input UpdateDateSpotReviewInput) (*UpdateDateSpotReviewOutput, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
-
-	existing, err := i.DateSpotReviewRepository.FindByID(ctx, input.ReviewID)
-	if err != nil {
-		return nil, apperror.NotFound()
-	}
-
 	review := &model.DateSpotReview{
 		Rate:    input.Rate,
 		Content: input.Content,
@@ -66,19 +51,13 @@ func (i *UpdateDateSpotReviewInteractor) Execute(ctx context.Context, input Upda
 		return nil, apperror.InternalServerError(err)
 	}
 
-	dateSpot, err := i.DateSpotRepository.FindByID(ctx, existing.DateSpotID)
-	if err != nil {
-		return nil, apperror.InternalServerError(err)
-	}
-
-	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, existing.DateSpotID)
+	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, input.DateSpotID)
 	if err != nil {
 		return nil, apperror.InternalServerError(err)
 	}
 
 	return &UpdateDateSpotReviewOutput{
 		ReviewID:        input.ReviewID,
-		DateSpot:        dateSpot,
 		DateSpotReviews: reviews,
 	}, nil
 }

--- a/internal/usecase/update_date_spot_review.go
+++ b/internal/usecase/update_date_spot_review.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
 	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
@@ -59,5 +60,36 @@ func (i *UpdateDateSpotReviewInteractor) Execute(ctx context.Context, input Upda
 	return &UpdateDateSpotReviewOutput{
 		ReviewID:        input.ReviewID,
 		DateSpotReviews: reviews,
+	}, nil
+}
+
+// NewUpdateDateSpotReviewInput parses string form values and constructs UpdateDateSpotReviewInput.
+// reviewID is provided as int (from route param). dateSpotIDStr, rateStr, contentStr are raw form values.
+func NewUpdateDateSpotReviewInput(reviewID int, dateSpotIDStr, rateStr, contentStr string) (UpdateDateSpotReviewInput, error) {
+	// parse date_spot_id
+	dateSpotID, err := strconv.Atoi(dateSpotIDStr)
+	if err != nil {
+		return UpdateDateSpotReviewInput{}, apperror.BadRequest("date_spot_id は整数で指定してください")
+	}
+
+	var rate *float64
+	if rateStr != "" {
+		r, err := strconv.ParseFloat(rateStr, 64)
+		if err != nil {
+			return UpdateDateSpotReviewInput{}, apperror.BadRequest("rate は数値で指定してください")
+		}
+		rate = &r
+	}
+
+	var content *string
+	if c := contentStr; c != "" {
+		content = &c
+	}
+
+	return UpdateDateSpotReviewInput{
+		ReviewID:   uint(reviewID),
+		DateSpotID: uint(dateSpotID),
+		Rate:       rate,
+		Content:    content,
 	}, nil
 }

--- a/internal/usecase/update_date_spot_review.go
+++ b/internal/usecase/update_date_spot_review.go
@@ -28,21 +28,36 @@ func (i *UpdateDateSpotReviewInput) Validate() error {
 }
 
 type UpdateDateSpotReviewOutput struct {
-	ReviewID uint
+	ReviewID        uint
+	DateSpot        *model.DateSpot
+	DateSpotReviews []*model.DateSpotReview
 }
 
 type UpdateDateSpotReviewInteractor struct {
 	DateSpotReviewRepository repository.DateSpotReviewRepository
+	DateSpotRepository       repository.DateSpotRepository
 }
 
-func NewUpdateDateSpotReviewUsecase(dateSpotReviewRepository repository.DateSpotReviewRepository) UpdateDateSpotReviewInputPort {
-	return &UpdateDateSpotReviewInteractor{DateSpotReviewRepository: dateSpotReviewRepository}
+func NewUpdateDateSpotReviewUsecase(
+	dateSpotReviewRepository repository.DateSpotReviewRepository,
+	dateSpotRepository repository.DateSpotRepository,
+) UpdateDateSpotReviewInputPort {
+	return &UpdateDateSpotReviewInteractor{
+		DateSpotReviewRepository: dateSpotReviewRepository,
+		DateSpotRepository:       dateSpotRepository,
+	}
 }
 
 func (i *UpdateDateSpotReviewInteractor) Execute(ctx context.Context, input UpdateDateSpotReviewInput) (*UpdateDateSpotReviewOutput, error) {
 	if err := input.Validate(); err != nil {
 		return nil, err
 	}
+
+	existing, err := i.DateSpotReviewRepository.FindByID(ctx, input.ReviewID)
+	if err != nil {
+		return nil, apperror.NotFound()
+	}
+
 	review := &model.DateSpotReview{
 		Rate:    input.Rate,
 		Content: input.Content,
@@ -50,5 +65,20 @@ func (i *UpdateDateSpotReviewInteractor) Execute(ctx context.Context, input Upda
 	if err := i.DateSpotReviewRepository.UpdateByID(ctx, input.ReviewID, review); err != nil {
 		return nil, apperror.InternalServerError(err)
 	}
-	return &UpdateDateSpotReviewOutput{ReviewID: input.ReviewID}, nil
+
+	dateSpot, err := i.DateSpotRepository.FindByID(ctx, existing.DateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	reviews, err := i.DateSpotReviewRepository.FindByDateSpotID(ctx, existing.DateSpotID)
+	if err != nil {
+		return nil, apperror.InternalServerError(err)
+	}
+
+	return &UpdateDateSpotReviewOutput{
+		ReviewID:        input.ReviewID,
+		DateSpot:        dateSpot,
+		DateSpotReviews: reviews,
+	}, nil
 }

--- a/internal/usecase/update_date_spot_review_test.go
+++ b/internal/usecase/update_date_spot_review_test.go
@@ -27,30 +27,22 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
-			FindByID(ctx, uint(1)).
-			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
-		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(nil)
 		reviewRepo.EXPECT().
 			FindByDateSpotID(ctx, uint(3)).
 			Return([]*model.DateSpotReview{}, nil)
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-		dateSpotRepo.EXPECT().
-			FindByID(ctx, uint(3)).
-			Return(&model.DateSpot{ID: 3, Name: "テストスポット"}, nil)
-
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
-			ReviewID: 1,
-			Rate:     &rate,
-			Content:  &content,
+			ReviewID:   1,
+			DateSpotID: 3,
+			Rate:       &rate,
+			Content:    &content,
 		})
 
 		require.NoError(t, err)
 		assert.Equal(t, uint(1), output.ReviewID)
-		assert.NotNil(t, output.DateSpot)
 		assert.NotNil(t, output.DateSpotReviews)
 	})
 
@@ -60,24 +52,17 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
-			FindByID(ctx, uint(1)).
-			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
-		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(nil)
 		reviewRepo.EXPECT().
 			FindByDateSpotID(ctx, uint(3)).
 			Return([]*model.DateSpotReview{}, nil)
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-		dateSpotRepo.EXPECT().
-			FindByID(ctx, uint(3)).
-			Return(&model.DateSpot{ID: 3, Name: "テストスポット"}, nil)
-
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
-			ReviewID: 1,
-			Rate:     &rate,
+			ReviewID:   1,
+			DateSpotID: 3,
+			Rate:       &rate,
 		})
 
 		require.NoError(t, err)
@@ -89,11 +74,11 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
-			ReviewID: 1,
+			ReviewID:   1,
+			DateSpotID: 3,
 		})
 
 		assert.Error(t, err)
@@ -103,48 +88,20 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	})
 
-	t.Run("error_review_not_found", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		reviewRepo.EXPECT().
-			FindByID(ctx, uint(1)).
-			Return(nil, errors.New("not found"))
-
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
-		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
-			ReviewID: 1,
-			Rate:     &rate,
-		})
-
-		assert.Error(t, err)
-		assert.Nil(t, output)
-		statusCode, _, _, ok := apperror.HTTPStatus(err)
-		assert.True(t, ok)
-		assert.Equal(t, http.StatusNotFound, statusCode)
-	})
-
 	t.Run("error_repository_update_failed", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
-			FindByID(ctx, uint(1)).
-			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
-		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(errors.New("db error"))
 
-		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
-
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
-			ReviewID: 1,
-			Rate:     &rate,
+			ReviewID:   1,
+			DateSpotID: 3,
+			Rate:       &rate,
 		})
 
 		assert.Error(t, err)

--- a/internal/usecase/update_date_spot_review_test.go
+++ b/internal/usecase/update_date_spot_review_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/daisuke-harada/date-courses-go/internal/apperror"
+	"github.com/daisuke-harada/date-courses-go/internal/domain/model"
 	repomock "github.com/daisuke-harada/date-courses-go/internal/domain/repository/mock"
 	"github.com/daisuke-harada/date-courses-go/internal/usecase"
 	"github.com/stretchr/testify/assert"
@@ -26,10 +27,21 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
+			FindByID(ctx, uint(1)).
+			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
+		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(nil)
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(3)).
+			Return([]*model.DateSpotReview{}, nil)
 
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			FindByID(ctx, uint(3)).
+			Return(&model.DateSpot{ID: 3, Name: "テストスポット"}, nil)
+
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
 			ReviewID: 1,
 			Rate:     &rate,
@@ -38,6 +50,8 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, uint(1), output.ReviewID)
+		assert.NotNil(t, output.DateSpot)
+		assert.NotNil(t, output.DateSpotReviews)
 	})
 
 	t.Run("success_with_rate_only", func(t *testing.T) {
@@ -46,10 +60,21 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
+			FindByID(ctx, uint(1)).
+			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
+		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(nil)
+		reviewRepo.EXPECT().
+			FindByDateSpotID(ctx, uint(3)).
+			Return([]*model.DateSpotReview{}, nil)
 
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+		dateSpotRepo.EXPECT().
+			FindByID(ctx, uint(3)).
+			Return(&model.DateSpot{ID: 3, Name: "テストスポット"}, nil)
+
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
 			ReviewID: 1,
 			Rate:     &rate,
@@ -64,9 +89,9 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
-		// リポジトリは呼ばれない
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
 
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
 			ReviewID: 1,
 		})
@@ -78,16 +103,45 @@ func TestUpdateDateSpotReviewInteractor_Execute(t *testing.T) {
 		assert.Equal(t, http.StatusUnprocessableEntity, statusCode)
 	})
 
+	t.Run("error_review_not_found", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
+		reviewRepo.EXPECT().
+			FindByID(ctx, uint(1)).
+			Return(nil, errors.New("not found"))
+
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
+		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
+			ReviewID: 1,
+			Rate:     &rate,
+		})
+
+		assert.Error(t, err)
+		assert.Nil(t, output)
+		statusCode, _, _, ok := apperror.HTTPStatus(err)
+		assert.True(t, ok)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
 	t.Run("error_repository_update_failed", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
 		reviewRepo := repomock.NewMockDateSpotReviewRepository(ctrl)
 		reviewRepo.EXPECT().
+			FindByID(ctx, uint(1)).
+			Return(&model.DateSpotReview{ID: 1, DateSpotID: 3}, nil)
+		reviewRepo.EXPECT().
 			UpdateByID(ctx, uint(1), gomock.Any()).
 			Return(errors.New("db error"))
 
-		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo)
+		dateSpotRepo := repomock.NewMockDateSpotRepository(ctrl)
+
+		interactor := usecase.NewUpdateDateSpotReviewUsecase(reviewRepo, dateSpotRepo)
 		output, err := interactor.Execute(ctx, usecase.UpdateDateSpotReviewInput{
 			ReviewID: 1,
 			Rate:     &rate,

--- a/internal/usecase/update_user.go
+++ b/internal/usecase/update_user.go
@@ -113,3 +113,32 @@ func (i *UpdateUserInteractor) Execute(ctx context.Context, input UpdateUserInpu
 
 	return &UpdateUserOutput{UserWithRelations: uwr}, nil
 }
+
+// NewUpdateUserInput builds UpdateUserInput from raw form string values.
+// Invalid gender values are treated as empty and left for Validate() to report.
+func NewUpdateUserInput(id int, name, email, genderStr, password, passwordConfirmation, imageStr string) (UpdateUserInput, error) {
+	var gender model.Gender
+	if genderStr != "" {
+		g := model.Gender(genderStr)
+		if g == model.GenderMale || g == model.GenderFemale {
+			gender = g
+		} else {
+			gender = ""
+		}
+	}
+
+	var image *string
+	if imageStr != "" {
+		image = &imageStr
+	}
+
+	return UpdateUserInput{
+		ID:                   uint(id),
+		Name:                 name,
+		Email:                email,
+		Gender:               gender,
+		Image:                image,
+		Password:             password,
+		PasswordConfirmation: passwordConfirmation,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- `internal/interface/handler/` の全ハンドラーで `map[string]interface{}` 等の raw 型によるレスポンス返却を廃止し、`internal/interface/openapi/api_types.gen.go` の型に統一
- usecase の `DeleteDateSpotReview` / `DeleteRelationship` が `Output` を返すように変更（DB の状態を呼び出し元に返せるよう拡充）
- `DateSpotReview` の CRUD 系 usecase に `DateSpotRepository` 依存を追加し、レビュー操作後のスポット情報を Output に含めるように変更

## 変更ファイル一覧（主要）

### openapi レスポンス変換関数
- `courses.go`: `BuildGetCoursesResponse` を削除し `NewCoursesResponse` / `NewCourseResponse` / `NewCreateCourseResponse` を追加
- `relationship.go`: `BuildDeleteRelationshipResponse` を追加

### handler
- `get_api_v1_courses.go`, `post_api_v1_courses.go`, `get_api_v1_courses_id.go`
- `get_api_v1_genres_id.go`, `put_api_v1_date_spots_id.go`
- `post_api_v1_date_spot_reviews.go`, `put_api_v1_date_spot_reviews_id.go`, `delete_api_v1_date_spot_reviews_id.go`
- `delete_api_v1_relationships_current_user_id_other_user_id.go`

### usecase / repository
- `delete_date_spot_review.go`, `delete_relationship.go` — Output 型を追加
- `create_date_spot_review.go`, `update_date_spot_review.go` — `DateSpotRepository` 依存追加
- `internal/domain/repository/date_spot_review_repository.go` — `FindByID` 追加
- `internal/infrastructure/persistence/date_spot_review_repository.go` — `FindByID` GORM 実装追加

## Test plan

- [x] `go test ./...` 全パス確認済み
- [x] `go build ./...` ビルドエラーなし確認済み
- usecase テスト（create / update / delete date_spot_review、delete_relationship）: 新規テストケース含む
- handler テスト: 全 8 ハンドラーのテストを更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)