### PR TITLE
feat(#109 Step2): Lambda プロジェクト構造の整備

### DIFF
--- a/cmd/lambda/monolith/main.go
+++ b/cmd/lambda/monolith/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"log"
+
+	iface "github.com/daisuke-harada/date-courses-go/internal/interface"
+	"github.com/daisuke-harada/date-courses-go/pkg/logger"
+)
+
+func main() {
+	logger.Init("date-courses-go", false)
+	defer logger.Close()
+
+	e, err := iface.NewEchoApp()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// TODO(Step 3): github.com/awslabs/aws-lambda-go-api-proxy/echo を使って
+	// Lambda ハンドラーとして起動する。現在はスケルトン。
+	_ = e
+}

--- a/internal/interface/server.go
+++ b/internal/interface/server.go
@@ -20,61 +20,75 @@ import (
 	echoMiddleware "github.com/labstack/echo/v4/middleware"
 )
 
-func Run(ctx context.Context) error {
-	notifyCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
+// NewEchoApp はDIコンテナを構築し、全ルートが登録済みの *echo.Echo を返します。
+// HTTP サーバーの起動は行いません。cmd/api と cmd/lambda で共用します。
+func NewEchoApp() (*echo.Echo, error) {
 	container := di.NewContainer()
 	container.MustProvide(NewEcho)
 	container.MustProvide(config.Get)
 	container.MustProvide(di.ProvideDB)
 	di.BuildContainer(container)
 
-	return container.Invoke(func(e *echo.Echo) error {
-		openapi.RegisterHandlers(e, handler.NewHandler(container))
+	var e *echo.Echo
+	if err := container.Invoke(func(echoInst *echo.Echo) {
+		openapi.RegisterHandlers(echoInst, handler.NewHandler(container))
+		e = echoInst
+	}); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
 
-		addr := ":1099"
-		srv := &http.Server{
-			Addr: addr,
+func Run(ctx context.Context) error {
+	notifyCtx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	e, err := NewEchoApp()
+	if err != nil {
+		return err
+	}
+
+	addr := ":1099"
+	srv := &http.Server{
+		Addr: addr,
+	}
+
+	// errCh をバッファ1にしているのは、select が notifyCtx.Done() 側を先に選ぶ可能性があるためです。
+	// もし errCh がバッファ0だと、select が notifyCtx.Done() を選んで先に進んだ後は errCh を受信する箇所が無くなるので、
+	// StartServer が shutdown の結果として戻ってきたタイミングで errCh <- nil/err がブロックし、
+	// 起動goroutineが終了できずに残り続ける(= goroutine leak っぽい状態)可能性があります。
+	errCh := make(chan error, 1)
+	go func() {
+		slog.InfoContext(notifyCtx, "server starting", "addr", addr)
+		// StartServer は shutdown 経由の停止時も http.ErrServerClosed を返します。
+		// それ以外のエラーは異常終了として扱います。
+		err := e.StartServer(srv)
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
 		}
+		errCh <- nil
+	}()
 
-		// errCh をバッファ1にしているのは、select が notifyCtx.Done() 側を先に選ぶ可能性があるためです。
-		// もし errCh がバッファ0だと、select が notifyCtx.Done() を選んで先に進んだ後は errCh を受信する箇所が無くなるので、
-		// StartServer が shutdown の結果として戻ってきたタイミングで errCh <- nil/err がブロックし、
-		// 起動goroutineが終了できずに残り続ける(= goroutine leak っぽい状態)可能性があります。
-		errCh := make(chan error, 1)
-		go func() {
-			slog.InfoContext(notifyCtx, "server starting", "addr", addr)
-			// StartServer は shutdown 経由の停止時も http.ErrServerClosed を返します。
-			// それ以外のエラーは異常終了として扱います。
-			err := e.StartServer(srv)
-			if err != nil && !errors.Is(err, http.ErrServerClosed) {
-				errCh <- err
-				return
-			}
-			errCh <- nil
-		}()
-
-		select {
-		case err := <-errCh:
-			if err != nil {
-				slog.ErrorContext(notifyCtx, "server stopped with error", "err", err)
-				return err
-			}
-		case <-notifyCtx.Done():
-			// notifyCtx はシグナルでも親ctxのキャンセルでも Done になります。
-			slog.InfoContext(notifyCtx, "context canceled", "err", notifyCtx.Err())
-		}
-
-		shutdownCtx, cancel := context.WithTimeout(notifyCtx, 10*time.Second)
-		defer cancel()
-		if err := e.Shutdown(shutdownCtx); err != nil {
-			slog.ErrorContext(ctx, "graceful shutdown failed", "err", err)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			slog.ErrorContext(notifyCtx, "server stopped with error", "err", err)
 			return err
 		}
-		slog.InfoContext(ctx, "server shutdown complete")
-		return nil
-	})
+	case <-notifyCtx.Done():
+		// notifyCtx はシグナルでも親ctxのキャンセルでも Done になります。
+		slog.InfoContext(notifyCtx, "context canceled", "err", notifyCtx.Err())
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(notifyCtx, 10*time.Second)
+	defer cancel()
+	if err := e.Shutdown(shutdownCtx); err != nil {
+		slog.ErrorContext(ctx, "graceful shutdown failed", "err", err)
+		return err
+	}
+	slog.InfoContext(ctx, "server shutdown complete")
+	return nil
 }
 
 func NewEcho(cfg *config.Config, userRepo repository.UserRepository) *echo.Echo {

--- a/makefile
+++ b/makefile
@@ -48,6 +48,16 @@ mock-usecase:
 		mockgen -source=$$f -destination=internal/usecase/mock/$$(basename $$f) -package=usecasemock; \
 	done
 
+# Lambda ビルド: provided.al2023 ランタイム向け (arm64)
+# モノリス Lambda（全ルート）。API 個別化時は build-lambda-<api-name> を追加する。
+build-lambda-monolith:
+	mkdir -p dist/lambda/monolith
+	GOARCH=arm64 GOOS=linux go build -o dist/lambda/monolith/bootstrap ./cmd/lambda/monolith
+
+# SAM CLI でローカル実行 (template.yaml が必要)
+local-lambda:
+	sam local start-api
+
 test:
 	go test ./...
 


### PR DESCRIPTION
## Summary

- `NewEchoApp()` を `Run()` から分離し、`cmd/api` と `cmd/lambda` で共有できるようにした
- `cmd/lambda/monolith/main.go` スケルトンを追加（Step 3 で Lambda アダプターを組み込む）
- `Makefile` に `build-lambda-monolith` / `local-lambda` ターゲットを追加

## API 個別 Lambda への移行について

将来の per-API Lambda 移行に対して邪魔にならない構造になっています。

```
cmd/lambda/
├── monolith/     ← 全ルート（今回追加）
│   └── main.go  ← NewEchoApp() を使う
├── date-spots/  ← 将来追加
│   └── main.go  ← NewEchoApp() をバイパスし最小 DI 構成
└── users/       ← 将来追加
    └── main.go
```

- `NewEchoApp()` は「全部乗せ」の便利関数にすぎず、per-API Lambda はそれを使わず独自の最小構成を持てる
- Makefile の `build-lambda-<name>` パターンも同様にスケールする

## Test plan

- [ ] `go build ./cmd/api/...` が通ること
- [ ] `make build-lambda-monolith` で `dist/lambda/monolith/bootstrap` が生成されること
- [ ] Step 3（Lambda アダプター組み込み）まで完全動作は保留

Closes #109 Step 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)