### PR TITLE
feat(#109 Step3): implement Lambda entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .envrc
+dist/
+samconfig.toml
+env.json
+.aws-sam/
+monolith

--- a/cmd/lambda/monolith/main.go
+++ b/cmd/lambda/monolith/main.go
@@ -18,6 +18,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	adapter := echoadapter.New(e)
+	adapter := echoadapter.NewV2(e)
+	adapter.StripBasePath("/prod")
 	lambda.Start(adapter.ProxyWithContext)
 }

--- a/cmd/lambda/monolith/main.go
+++ b/cmd/lambda/monolith/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/aws/aws-lambda-go/lambda"
+	echoadapter "github.com/awslabs/aws-lambda-go-api-proxy/echo"
 	iface "github.com/daisuke-harada/date-courses-go/internal/interface"
 	"github.com/daisuke-harada/date-courses-go/pkg/logger"
 )
@@ -16,7 +18,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// TODO(Step 3): github.com/awslabs/aws-lambda-go-api-proxy/echo を使って
-	// Lambda ハンドラーとして起動する。現在はスケルトン。
-	_ = e
+	adapter := echoadapter.New(e)
+	lambda.Start(adapter.ProxyWithContext)
 }

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
+	github.com/aws/aws-lambda-go v1.41.0 // indirect
+	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/google/uuid v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/aws/aws-lambda-go v1.41.0 h1:l/5fyVb6Ud9uYd411xdHZzSf2n86TakxzpvIoz7l+3Y=
+github.com/aws/aws-lambda-go v1.41.0/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
+github.com/awslabs/aws-lambda-go-api-proxy v0.16.2 h1:CJyGEyO1CIwOnXTU40urf0mchf6t3voxpvUDikOU9LY=
+github.com/awslabs/aws-lambda-go-api-proxy v0.16.2/go.mod h1:vxxjwBHe/KbgFeNlAP/Tvp4SsVRL3WQamcWRxqVh0z0=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ deps:
 docker-up:
 	docker compose up -d
 	# wait for MySQL to be ready before proceeding
-	docker compose exec db bash -c 'until mysqladmin ping -u "${DB_USER}" -p"${DB_ROOT_PASSWORD}" --silent 2>/dev/null; do sleep 1; done'
+	docker compose exec db bash -c 'until mysqladmin ping -u "${DB_USER}" -p"${DB_PASSWORD}" --silent 2>/dev/null; do sleep 1; done'
 
 gen: openapi-generate go-generate
 
@@ -58,6 +58,25 @@ build-lambda-monolith:
 local-lambda:
 	sam local start-api
 
+sam-build: build-lambda-monolith
+	sam build
+
+sam-deploy: sam-build
+	sam deploy \
+		--stack-name date-courses-go \
+		--region ap-northeast-1 \
+		--no-confirm-changeset \
+		--no-fail-on-empty-changeset \
+		--capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+		--resolve-s3 \
+		--profile sam-access
+
+sam-delete:
+	aws cloudformation delete-stack \
+		--stack-name date-courses-go \
+		--region ap-northeast-1 \
+		--profile sam-access
+
 test:
 	go test ./...
 
@@ -72,3 +91,5 @@ db-seed:
 
 db-drop:
 	docker compose exec db mysql -u "${DB_USER}" -p"${DB_PASSWORD}" -e "DROP DATABASE IF EXISTS ${DB_NAME}; CREATE DATABASE ${DB_NAME};"
+
+

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,122 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: date-courses-go – HTTP API + Lambda monolith (arm64 / provided.al2023)
+
+# DB は TiDB Cloud（外部エンドポイント）のため VPC 設定は不要。
+# シークレット管理の詳細は Step 5（samconfig.toml / SSM）で確定する。
+
+Globals:
+  Function:
+    Timeout: 30
+    MemorySize: 256
+    Architectures:
+      - arm64
+    Runtime: provided.al2023
+
+Parameters:
+  Stage:
+    Type: String
+    Default: prod
+    AllowedValues: [prod, staging]
+    Description: Deployment stage name
+  DbHost:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/db-host
+  DbPort:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/db-port
+  DbUser:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/db-user
+  DbPassword:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/db-password
+  DbName:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/db-name
+  JwtSecretKey:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/jwt-secret-key
+  GoogleMapsApiKey:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /date-course-go/prod/google-maps-api-key
+
+Resources:
+  DateCoursesFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: go1.x
+    Properties:
+      FunctionName: !Sub date-courses-go-${Stage}
+      CodeUri: cmd/lambda/monolith/
+      Handler: bootstrap
+      Description: date-courses-go API handler
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Environment:
+        Variables:
+          DB_HOST: !Ref DbHost
+          DB_PORT: !Ref DbPort
+          DB_USER: !Ref DbUser
+          DB_PASSWORD: !Ref DbPassword
+          DB_NAME: !Ref DbName
+          DB_TLS: "true"
+          DB_MAX_OPEN_CONNS: "25"
+          DB_MAX_IDLE_CONNS: "25"
+          DB_CONN_MAX_LIFETIME: "5m"
+          JWT_SECRET_KEY: !Ref JwtSecretKey
+          GOOGLE_MAPS_API_KEY: !Ref GoogleMapsApiKey
+      Events:
+        ApiProxy:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref DateCoursesHttpApi
+            Path: /{proxy+}
+            Method: ANY
+        ApiRoot:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref DateCoursesHttpApi
+            Path: /
+            Method: ANY
+
+  DateCoursesHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: !Ref Stage
+      CorsConfiguration:
+        AllowOrigins:
+          - "*"
+        AllowMethods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - OPTIONS
+        AllowHeaders:
+          - Content-Type
+          - Authorization
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub date-courses-go-lambda-role-${Stage}
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+Outputs:
+  ApiEndpoint:
+    Description: HTTP API endpoint URL
+    Value: !Sub "https://${DateCoursesHttpApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}"
+  FunctionName:
+    Description: Lambda function name
+    Value: !Ref DateCoursesFunction
+  FunctionArn:
+    Description: Lambda function ARN
+    Value: !GetAtt DateCoursesFunction.Arn


### PR DESCRIPTION
## Summary
- `github.com/awslabs/aws-lambda-go-api-proxy/echo` と `github.com/aws/aws-lambda-go` を依存追加
- `cmd/lambda/monolith/main.go` の TODO を実装し、既存の Echo ルーター（`NewEchoApp`）を Lambda ハンドラーとして起動
- `echoadapter.New(e)` でアダプターを生成し、`lambda.Start(adapter.ProxyWithContext)` で API Gateway イベントを Echo に橋渡し

## Test plan
- [ ] `make build-lambda-monolith` でクロスコンパイル（arm64/linux）が通ること
- [ ] `go build ./...` でビルドエラーがないこと

Closes #109 Step3

🤖 Generated with [Claude Code](https://claude.com/claude-code)