### PR TITLE
feat: SAMデプロイ時にAPI Gateway URLをSSMへ書き込む

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -96,6 +96,14 @@ Resources:
           - Content-Type
           - Authorization
 
+  SsmApiEndpoint:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/date-course-go/${Stage}/api-endpoint"
+      Type: String
+      Value: !Sub "https://${DateCoursesHttpApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}"
+      Description: API Gateway endpoint URL (Terraform / React 向け)
+
   LambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Summary

- `template.yaml` に `AWS::SSM::Parameter` リソース (`SsmApiEndpoint`) を追加
- SAM デプロイ完了時に CloudFormation が `/date-course-go/{Stage}/api-endpoint` へ URL を自動書き込みする
- Terraform がこのパラメータを参照して Cloudflare Pages の環境変数 `REACT_APP_BACKEND_DOMAIN_API` に設定する

## 連携フロー

```
sam deploy
  → CloudFormation が API Gateway を作成
  → SsmApiEndpoint リソースが SSM へ URL を書き込む
       (/date-course-go/prod/api-endpoint)
  → terraform apply 時に data "aws_ssm_parameter" が URL を取得
  → Cloudflare Pages の環境変数に自動反映
```

## Test plan

- [ ] `sam deploy` 後に SSM パラメータ `/date-course-go/prod/api-endpoint` が存在すること
- [ ] 値が `https://xxxx.execute-api.ap-northeast-1.amazonaws.com/prod` 形式であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)